### PR TITLE
Release automation tool

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,29 @@
+name: Python Tests
+
+on:
+  push:
+    branches:
+      - '2.x-dev'
+      - '2.x'
+  pull_request:
+    branches:
+      - '2.x-dev'
+      - '2.x'
+
+permissions:
+  contents: read
+
+jobs:
+  python-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run tests
+        run: pytest tests/python

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 PYTHON = python
 PIP = pip
+FORCE_RELEASE_FLAG = $(if $(filter 1,$(FORCE)),--force-release,)
 
 .DEFAULT_GOAL = help
 .PHONY        : help
@@ -29,6 +30,12 @@ release-dry-run: ## Shows planned release actions without mutating anything
 
 release-status: ## Shows per-package release status without mutating anything
 	. venv/bin/activate; $(PYTHON) ./scripts/release.py --config=./repository.json --status --base-branch "$(BASE_BRANCH)" --release-branch "$(RELEASE_BRANCH)" "$(RELEASE_NAME)"
+
+release-current: ## Creates releases directly from the current base branch; use FORCE=1 to bypass no-commit checks
+	. venv/bin/activate; $(PYTHON) ./scripts/release.py --config=./repository.json --release-current $(FORCE_RELEASE_FLAG) --base-branch "$(BASE_BRANCH)" "$(RELEASE_NAME)"
+
+release-current-dry-run: ## Shows planned direct-release actions; use FORCE=1 to preview forced releases
+	. venv/bin/activate; $(PYTHON) ./scripts/release.py --config=./repository.json --release-current --dry-run $(FORCE_RELEASE_FLAG) --base-branch "$(BASE_BRANCH)" "$(RELEASE_NAME)"
 
 clean: ## Clean the build system
 	$(PYTHON) ./scripts/clean.py --config=./repository.json

--- a/Makefile
+++ b/Makefile
@@ -9,21 +9,28 @@ help: ## Outputs this help screen
 
 venv: venv/touchfile
 
-venv/touchfile: scripts/requirements.txt
-	cd ./scripts; test -d venv || virtualenv venv
-	cd ./scripts; . venv/bin/activate; $(PIP) install -Ur requirements.txt
-	cd ./scripts; touch venv/touchfile
+venv/touchfile: ./requirements.txt
+	test -d venv || virtualenv venv
+	. venv/bin/activate; $(PIP) install -Ur requirements.txt
+	touch venv/touchfile
 
 init: ## Initializes the sub-repositories for build system
 init: venv
-	cd ./scripts; . venv/bin/activate; $(PYTHON) ./init.py --config=../repository.json
+	. venv/bin/activate; $(PYTHON) ./scripts/init.py --config=./repository.json $(INIT_ARGS)
 
 release-prepare: ## Prepares releases
-	cd ./scripts; . venv/bin/activate; $(PYTHON) ./release.py --config=../repository.json --base-branch 2.x "$(RELEASE_NAME)"
+	. venv/bin/activate; $(PYTHON) ./scripts/release.py --config=./repository.json --base-branch "$(BASE_BRANCH)" --release-branch "$(RELEASE_BRANCH)" "$(RELEASE_NAME)"
 
 release-merge: ## Merges releases in GitHub
-	cd ./scripts; . venv/bin/activate; $(PYTHON) ./release.py --config=../repository.json --merge --base-branch 2.x "$(RELEASE_NAME)"
+	. venv/bin/activate; $(PYTHON) ./scripts/release.py --config=./repository.json --merge --base-branch "$(BASE_BRANCH)" --release-branch "$(RELEASE_BRANCH)" "$(RELEASE_NAME)"
+
+release-dry-run: ## Shows planned release actions without mutating anything
+	. venv/bin/activate; $(PYTHON) ./scripts/release.py --config=./repository.json --dry-run --base-branch "$(BASE_BRANCH)" --release-branch "$(RELEASE_BRANCH)" "$(RELEASE_NAME)"
+
+release-status: ## Shows per-package release status without mutating anything
+	. venv/bin/activate; $(PYTHON) ./scripts/release.py --config=./repository.json --status --base-branch "$(BASE_BRANCH)" --release-branch "$(RELEASE_BRANCH)" "$(RELEASE_NAME)"
 
 clean: ## Clean the build system
-	cd ./scripts; rm -rf venv __pycache__
-	cd ./scripts; find -iname "*.pyc" -delete
+	$(PYTHON) ./scripts/clean.py --config=./repository.json
+	rm -rf venv __pycache__
+	find -iname "*.pyc" -delete

--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # micro-dev
-Development Framework 
+Development Framework
+
+The repository initialization process now fetches remote history and ensures
+the package repository is in sync with the monorepo. Any local changes after
+initialization are logged as warnings.
+The release scripts require the `gh` GitHub CLI to be installed and accessible
+in the `PATH`. Version numbers are automatically derived from existing git
+tags and release notes are collected from merge commit messages.
+
+## Running Python tests
+
+Install dependencies:
+
+```
+pip install -r requirements.txt
+```
+
+Execute the test suite using:
+
+```
+pytest tests/python
+```
+
+No additional environment variables are required.

--- a/composer.json
+++ b/composer.json
@@ -13,32 +13,35 @@
         "php": "^8.2",
         "ext-dom": "*",
         "ext-libxml": "*",
-        "ext-redis": "*",
         "ext-pcntl": "*",
+        "ext-redis": "*",
         "doctrine/orm": "^2",
         "elasticsearch/elasticsearch": "^8",
-        "nette/php-generator": "^4",
-        "psr/log": "^1 || ^2 || ^3",
-        "symfony/property-access": "^5.4 || ^6.1 || ^6.2 || ^6.3",
-        "symfony/finder": "^6.2 || ^6.3",
-        "symfony/validator": "^5.4.15 || ^6",
-        "symfony/console": "^6.0",
-        "symfony/http-foundation": "^6.2 || ^6.3",
-        "symfony/serializer": "^6.2 || ^6.3",
         "firebase/php-jwt": "^6",
-        "php-amqplib/php-amqplib": "^3.1",
-        "php-ffmpeg/php-ffmpeg": "^1.0",
         "league/flysystem": "^3.0",
         "league/oauth2-client": "^2",
-        "psr/cache": "^3.0",
-        "psr/simple-cache": "^3.0",
-        "symfony/cache": "^6",
         "monolog/monolog": "^3",
-        "twig/twig": "^3",
-        "ramsey/uuid": "^4.2"
-    },
-    "replace": {
-        "micro/kernel": "self.version"
+        "nette/php-generator": "^4",
+        "nyholm/psr7": "^1.8",
+        "php-amqplib/php-amqplib": "^3.1",
+        "php-ffmpeg/php-ffmpeg": "^1.0",
+        "psr/cache": "^3.0",
+        "psr/container": "^2.0",
+        "psr/log": "^1 || ^2 || ^3",
+        "psr/simple-cache": "^3.0",
+        "ramsey/uuid": "^4.2",
+        "spiral/roadrunner": "^2025.1.13",
+        "spiral/tokenizer": ">=2.7",
+        "symfony/cache": "^6",
+        "symfony/console": "^6.0",
+        "symfony/finder": "^6",
+        "symfony/http-foundation": "^6.2",
+        "symfony/property-access": "^5.4 || ^6",
+        "symfony/psr-http-message-bridge": "^2.3",
+        "symfony/serializer": "^6.2",
+        "symfony/validator": "^5.4 || ^6",
+        "temporal/sdk": ">=2.0",
+        "twig/twig": "^3"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.34",
@@ -47,6 +50,10 @@
         "symfony/intl": "^5.4 || ^6",
         "symfony/var-dumper": "^5.4 || ^6"
     },
+    "replace": {
+        "micro/kernel": "self.version"
+    },
+    "minimum-stability": "dev",
     "autoload": {
         "psr-4": {
             "Micro\\Framework\\": "src/Micro/Framework",
@@ -60,7 +67,6 @@
             "php-http/discovery": true
         }
     },
-    "minimum-stability": "dev",
     "scripts": {
         "post-install-cmd": [
             "@auto-scripts"
@@ -68,8 +74,7 @@
         "post-update-cmd": [
             "@auto-scripts"
         ],
-        "auto-scripts": [
-        ],
+        "auto-scripts": [],
         "front-build": [
             "yarn install",
             "yarn build"
@@ -80,17 +85,17 @@
             "@test-php-cs-try",
             "@test-unit"
         ],
+        "test-php-cs-fix": [
+            "php tests/tools/php-cs-fixer/vendor/bin/php-cs-fixer fix --verbose --using-cache=no"
+        ],
+        "test-php-cs-try": [
+            "php tests/tools/php-cs-fixer/vendor/bin/php-cs-fixer fix --verbose --dry-run --using-cache=no"
+        ],
         "test-phpstan": [
             "php tests/tools/phpstan/vendor/bin/phpstan"
         ],
         "test-psalm": [
             "php tests/tools/psalm/vendor/bin/psalm"
-        ],
-        "test-php-cs-try": [
-            "php tests/tools/php-cs-fixer/vendor/bin/php-cs-fixer fix --verbose --dry-run --using-cache=no"
-        ],
-        "test-php-cs-fix": [
-            "php tests/tools/php-cs-fixer/vendor/bin/php-cs-fixer fix --verbose --using-cache=no"
         ],
         "test-unit": [
             "php vendor/bin/phpunit"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+GitPython~=3.1.43
+requests~=2.32.0
+pytest

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,159 @@
+# Scripts
+
+These scripts manage the nested package repositories inside `micro-dev` and are used to prepare, review, merge, and clean releases for all Micro packages listed in [`repository.json`](../repository.json).
+
+## Prerequisites
+
+- Run all commands from the `micro-dev` repository root.
+- Install Python dependencies with `make venv`.
+- Install GitHub CLI (`gh`) and make sure `gh auth status` succeeds.
+- Make sure every package listed in `repository.json` has been initialized with `make init`.
+- Know the two branches you want to use:
+  - `BASE_BRANCH`: the branch packages are released onto, for example `2.x`
+  - `RELEASE_BRANCH`: the release branch or PR head, for example `release/2026-03-19`
+
+## Initialize Package Repositories
+
+Initialize all nested package repositories:
+
+```bash
+make init
+```
+
+This creates or updates git metadata in the package directories and switches each package to the current monorepo branch when possible.
+
+If the current monorepo branch does not exist in the package repositories, you can create the missing branch from an existing remote branch:
+
+```bash
+make init INIT_ARGS="--from-branch=2.x"
+```
+
+Current init fallback behavior:
+
+- The target branch defaults to the current monorepo branch.
+- If that target branch already exists in a package repository, init checks it out.
+- If it does not exist and `--from-branch=<branch-name>` is provided, init creates the target branch from `origin/<branch-name>`.
+- If the fallback branch does not exist remotely, the package is reported as blocked.
+
+If you also want newly created missing branches to be pushed to GitHub, use the opt-in push flag:
+
+```bash
+make init INIT_ARGS="--from-branch=2.x --push-missing-branches"
+```
+
+Equivalent direct script usage:
+
+```bash
+python ./scripts/init.py --config=./repository.json --from-branch=2.x
+python ./scripts/init.py --config=./repository.json --from-branch=2.x --push-missing-branches
+```
+
+If you want to remove that nested git metadata and return to a clean non-initialized state:
+
+```bash
+make clean
+```
+
+`make clean` removes the package-level `.git` metadata, removes the Python virtualenv, and deletes Python cache files.
+
+## Release Flow
+
+Use the Make targets below. They are thin wrappers around `scripts/release.py`.
+
+### 1. Inspect Current State
+
+Show the current per-package release status without mutating anything:
+
+```bash
+make release-status BASE_BRANCH=2.x RELEASE_BRANCH=release/2026-03-19 RELEASE_NAME=v2.4.0
+```
+
+This reports whether each package is blocked, already released, has an open PR, or would create a missing release.
+
+### 2. Preview the Exact Actions
+
+Show what the release script would do without mutating git or GitHub:
+
+```bash
+make release-dry-run BASE_BRANCH=2.x RELEASE_BRANCH=release/2026-03-19 RELEASE_NAME=v2.4.0
+```
+
+Use this before every real run. It shows the action for each package, for example:
+
+- `would merge PR ... and create release ...`
+- `would create missing release ...`
+- `noop: merged PR already released ...`
+- `blocked: remote base branch ... is missing`
+- `blocked: local changes or untracked files are present`
+
+### 3. Prepare the Release
+
+Prepare all package release branches and open PRs:
+
+```bash
+make release-prepare BASE_BRANCH=2.x RELEASE_BRANCH=release/2026-03-19 RELEASE_NAME=v2.4.0
+```
+
+Current prepare-mode behavior:
+
+- It requires the remote `BASE_BRANCH` and `RELEASE_BRANCH` checks to pass for all packages before processing starts.
+- It fails early if any package repository has local tracked changes or untracked files.
+- If package processing succeeds, it commits with the message `Update <RELEASE_NAME> for <package>`, pushes the release branch, and opens a PR when one is not already open.
+
+### 4. Merge PRs and Publish Releases
+
+Merge the open release PRs and create GitHub releases for all packages:
+
+```bash
+make release-merge BASE_BRANCH=2.x RELEASE_BRANCH=release/2026-03-19 RELEASE_NAME=v2.4.0
+```
+
+Current merge-mode behavior:
+
+- It verifies `gh` is installed and authenticated before starting.
+- It verifies remote branch state before package processing starts.
+- It fetches tags before computing the next package version.
+- It merges open PRs with squash merge.
+- It creates GitHub release notes from commit subjects since the previous release tag.
+- If a PR was already merged but the release was not created, it can recover by creating the missing release.
+
+### 5. Optional Merge Variants
+
+Merge PRs but skip creating GitHub releases:
+
+```bash
+python ./scripts/release.py --config=./repository.json --merge --no-release --base-branch 2.x --release-branch release/2026-03-19 v2.4.0
+```
+
+Preview merge behavior without mutating anything:
+
+```bash
+python ./scripts/release.py --config=./repository.json --merge --dry-run --base-branch 2.x --release-branch release/2026-03-19 v2.4.0
+```
+
+## Script Help
+
+Every script in this folder supports `--help`, for example:
+
+```bash
+python ./scripts/init.py --help
+python ./scripts/release.py --help
+python ./scripts/clean.py --help
+```
+
+## Recommended Operator Sequence
+
+Use this order for a full release:
+
+1. `make init`
+2. `make release-status BASE_BRANCH=... RELEASE_BRANCH=... RELEASE_NAME=...`
+3. `make release-dry-run BASE_BRANCH=... RELEASE_BRANCH=... RELEASE_NAME=...`
+4. `make release-prepare BASE_BRANCH=... RELEASE_BRANCH=... RELEASE_NAME=...`
+5. Review the created PRs in GitHub
+6. `make release-merge BASE_BRANCH=... RELEASE_BRANCH=... RELEASE_NAME=...`
+
+If you need to undo the nested package initialization afterward:
+
+```bash
+make clean
+```

--- a/scripts/clean.py
+++ b/scripts/clean.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+import argparse
+import logging
+import os
+import shutil
+
+from packages import read_packages
+
+logging.basicConfig(level=logging.INFO)
+
+
+def remove_git_metadata(package_directory: str) -> bool:
+    git_path = os.path.join(package_directory, '.git')
+
+    if os.path.isdir(git_path) and not os.path.islink(git_path):
+        shutil.rmtree(git_path)
+        logging.info(f'Removed git directory from {package_directory}')
+        return True
+
+    if os.path.exists(git_path):
+        os.remove(git_path)
+        logging.info(f'Removed git file from {package_directory}')
+        return True
+
+    logging.info(f'No git metadata found in {package_directory}')
+    return False
+
+
+def main(config_file: str) -> list[str]:
+    if not config_file:
+        raise ValueError('No config file specified.')
+
+    packages = read_packages(config_file)
+    cleaned_packages = []
+
+    for _, folder in packages.items():
+        if remove_git_metadata(folder):
+            cleaned_packages.append(folder)
+
+    return cleaned_packages
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Remove git metadata created during multi-repository initialization.')
+    parser.add_argument('--config', '-c', required=True, help='Path to the config json file')
+    app_args = parser.parse_args()
+
+    config_file_path = os.path.abspath(app_args.config)
+    working_dir = os.path.dirname(config_file_path)
+    os.chdir(working_dir)
+
+    main(config_file_path)

--- a/scripts/clean_composer.py
+++ b/scripts/clean_composer.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+import argparse
+import logging
+import os
+import shutil
+
+from packages import read_packages
+
+logging.basicConfig(level=logging.INFO)
+
+
+def remove_path(path: str, dry_run: bool) -> bool:
+    if not os.path.lexists(path):
+        logging.info(f'Skipped missing path: {path}')
+        return False
+
+    if dry_run:
+        logging.info(f'Would remove: {path}')
+        return True
+
+    if os.path.isdir(path) and not os.path.islink(path):
+        shutil.rmtree(path)
+    else:
+        os.remove(path)
+
+    logging.info(f'Removed: {path}')
+    return True
+
+
+def clean_package(package: str, folder: str, dry_run: bool) -> list[str]:
+    removed_paths = []
+
+    for path in (
+        os.path.join(folder, 'vendor'),
+        os.path.join(folder, 'composer.lock'),
+    ):
+        if remove_path(path, dry_run):
+            removed_paths.append(path)
+
+    if not removed_paths:
+        logging.info(f'No Composer artifacts found in {package}')
+
+    return removed_paths
+
+
+def main(config_file: str, dry_run: bool) -> dict[str, list[str]]:
+    if not config_file:
+        raise ValueError('No config file specified.')
+
+    packages = read_packages(config_file)
+    cleaned_packages = {}
+
+    for package, folder in packages.items():
+        removed_paths = clean_package(package, folder, dry_run)
+        if removed_paths:
+            cleaned_packages[package] = removed_paths
+
+    return cleaned_packages
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Remove Composer artifacts from all configured package repositories.')
+    parser.add_argument('--config', '-c', default='./repository.json', help='Path to the config json file')
+    parser.add_argument('--dry-run', action='store_true', help='Print paths that would be removed without deleting them')
+    app_args = parser.parse_args()
+
+    config_file_path = os.path.abspath(app_args.config)
+    working_dir = os.path.dirname(config_file_path)
+    os.chdir(working_dir)
+
+    main(config_file_path, app_args.dry_run)

--- a/scripts/git_commands.py
+++ b/scripts/git_commands.py
@@ -1,7 +1,6 @@
-
 import os, logging
 
-from git import Repo, InvalidGitRepositoryError
+from git import Repo, InvalidGitRepositoryError, GitCommandError
 
 class NothingToCommitException(Exception):
     pass
@@ -11,6 +10,46 @@ class MissingBranchError(Exception):
 
 class BranchNotActiveError(Exception):
     pass
+
+class RepositoryDirtyError(Exception):
+    pass
+
+class TagAlreadyExistsError(Exception):
+    pass
+
+class MissingBaseBranchError(Exception):
+    pass
+
+
+def has_commits(repository: Repo) -> bool:
+    try:
+        return repository.head.is_valid()
+    except (TypeError, ValueError):
+        return False
+
+
+def is_unborn_repository_with_worktree(repository: Repo) -> bool:
+    return not has_commits(repository) and bool(repository.untracked_files)
+
+
+def attach_head_to_branch(repository: Repo, branch_name: str, upstream_branch: str | None = None):
+    repository.git.symbolic_ref('HEAD', f'refs/heads/{branch_name}')
+    logging.info(f"Attached repository HEAD to local branch '{branch_name}' without changing files")
+
+    if upstream_branch:
+        with repository.config_writer() as config:
+            config.set_value(f'branch "{branch_name}"', 'remote', repository.remote().name)
+            config.set_value(f'branch "{branch_name}"', 'merge', f'refs/heads/{upstream_branch}')
+        logging.info(f"Configured branch '{branch_name}' to track '{upstream_branch}'")
+
+
+def checkout_unborn_repository_to_remote_branch(repository: Repo, branch_name: str, remote_ref):
+    if branch_name not in repository.heads:
+        local_branch = repository.create_head(branch_name, remote_ref.commit)
+        local_branch.set_tracking_branch(remote_ref)
+    repository.heads[branch_name].checkout(force=True)
+    repository.git.reset('--hard', remote_ref.name)
+    logging.info(f"Checked out branch '{branch_name}' from remote '{remote_ref.name}' for unborn repository")
 
 def fetch(func):
     def wrapper(repository: Repo, package: str, *args, **kwargs):
@@ -23,9 +62,16 @@ def fetch(func):
 def create_or_update_branch(repository: Repo, package: str, branch_name: str):
     if branch_name in repository.heads:
         logging.info(f'Branch {branch_name} exists.')
-        if repository.active_branch.name != branch_name:
-            raise BranchNotActiveError(f'Branch {branch_name} already exists but is not active.')
-        logging.info(f"Repository is already on branch '{branch_name}'")
+        repository.heads[branch_name].checkout()
+        logging.info(f"Switched to existing branch '{branch_name}'")
+        return
+
+    remote_branch = next((ref for ref in repository.remotes.origin.refs if ref.remote_head == branch_name), None)
+    if remote_branch:
+        new_branch = repository.create_head(branch_name, remote_branch.commit)
+        new_branch.set_tracking_branch(remote_branch)
+        new_branch.checkout()
+        logging.info(f"Tracking branch '{branch_name}' created and switched to.")
     else:
         new_branch = repository.create_head(branch_name)
         new_branch.checkout()
@@ -64,6 +110,78 @@ def push_changes(repository: Repo):
 def get_repository(directory: str) -> Repo:
     return Repo(directory)
 
+def fetch_tags(repository: Repo):
+    repository.git.fetch('--tags')
+    logging.info('Fetched remote tags')
+
+def fetch_remote(repository: Repo):
+    repository.git.fetch('origin')
+    logging.info('Fetched remote branches')
+
+def has_remote_branch(repository: Repo, branch_name: str) -> bool:
+    return any(ref.remote_head == branch_name for ref in repository.remotes.origin.refs)
+
+
+@fetch
+def create_branch_from_remote(
+    repository: Repo,
+    package: str,
+    target_branch: str,
+    from_branch: str,
+    push_missing_branch: bool = False
+):
+    if repository.is_dirty(untracked_files=True) and not is_unborn_repository_with_worktree(repository):
+        raise RepositoryDirtyError(
+            f'Repository for {package} has local changes; refusing to create branch automatically.'
+        )
+
+    remote_target = next((ref for ref in repository.remotes.origin.refs if ref.remote_head == target_branch), None)
+    if is_unborn_repository_with_worktree(repository):
+        if remote_target:
+            checkout_unborn_repository_to_remote_branch(repository, target_branch, remote_target)
+            return
+
+        remote_base = next((ref for ref in repository.remotes.origin.refs if ref.remote_head == from_branch), None)
+        if not remote_base:
+            raise MissingBaseBranchError(
+                f'Base branch {from_branch} does not exist in {package}; cannot create {target_branch}'
+            )
+
+        checkout_unborn_repository_to_remote_branch(repository, target_branch, remote_base)
+        if push_missing_branch:
+            repository.git.push('--set-upstream', repository.remote().name, target_branch)
+            repository.git.fetch()
+            repository.heads[target_branch].set_tracking_branch(repository.remotes.origin.refs[target_branch])
+            logging.info(f"Pushed missing branch '{target_branch}' to origin for {package}")
+        return
+
+    if remote_target:
+        if target_branch not in repository.heads:
+            local_branch = repository.create_head(target_branch, remote_target.commit)
+            local_branch.set_tracking_branch(remote_target)
+        repository.heads[target_branch].checkout()
+        logging.info(f"Checked out existing remote branch '{target_branch}' for {package}")
+        return
+
+    remote_base = next((ref for ref in repository.remotes.origin.refs if ref.remote_head == from_branch), None)
+    if not remote_base:
+        raise MissingBaseBranchError(
+            f'Base branch {from_branch} does not exist in {package}; cannot create {target_branch}'
+        )
+
+    if target_branch in repository.heads:
+        local_branch = repository.heads[target_branch]
+    else:
+        local_branch = repository.create_head(target_branch, remote_base.commit)
+    local_branch.checkout()
+    logging.info(f"Created local branch '{target_branch}' from '{from_branch}' for {package}")
+
+    if push_missing_branch:
+        repository.git.push('--set-upstream', repository.remote().name, local_branch.name)
+        repository.git.fetch()
+        local_branch.set_tracking_branch(repository.remotes.origin.refs[target_branch])
+        logging.info(f"Pushed missing branch '{target_branch}' to origin for {package}")
+
 def ensure_folder_exists(func):
     def wrapper(package_directory: str, *args, **kwargs):
         if not os.path.exists(package_directory):
@@ -84,7 +202,13 @@ def change_directory(func):
 
 @ensure_folder_exists
 @change_directory
-def init_repository(package_directory: str, package_repo: str) -> Repo:
+def init_repository(package_directory: str, package_repo: str, branch_name: str | None = None) -> Repo:
+    """Initializes a package repository and synchronizes it with ``origin``.
+
+    The function fetches remote history from ``origin`` and prepares local
+    tracking for the requested branch when available. It does not hard reset or
+    overwrite local changes.
+    """
     try:
         repository = Repo('.')
     except InvalidGitRepositoryError:
@@ -93,9 +217,20 @@ def init_repository(package_directory: str, package_repo: str) -> Repo:
     if 'origin' not in repository.remotes:
         logging.info(f'Adding remote origin {package_repo} to {package_directory}')
         repository.create_remote('origin', package_repo)
-    # if repository.remotes.origin.url != package_repo:
-    #     logging.info(f'Updating remote origin {package_repo} to {package_directory}')
-    #     repository.remotes.origin.url = package_repo
+
+    origin = repository.remotes.origin
+    origin.fetch()
+
+    if branch_name:
+        remote_branch = next((ref for ref in origin.refs if ref.remote_head == branch_name), None)
+        if remote_branch and branch_name not in repository.heads:
+            branch = repository.create_head(branch_name, remote_branch.commit)
+            branch.set_tracking_branch(remote_branch)
+            logging.info(f"Tracking branch '{branch_name}' created during initialization")
+
+    if repository.is_dirty(untracked_files=True) and not is_unborn_repository_with_worktree(repository):
+        logging.warning(f'Repository {package_directory} is not clean after initialization')
+
     return repository
 
 def update_repository_remote_link(repository: Repo, remote_name: str, remote_url: str) -> None:
@@ -126,8 +261,30 @@ def ensure_already_branch(func):
 @ensure_already_branch
 def checkout(repository: Repo, package: str, branch: str):
     try:
+        remote_branch = next((ref for ref in repository.remotes.origin.refs if ref.remote_head == branch), None)
+        if is_unborn_repository_with_worktree(repository):
+            if not remote_branch:
+                raise MissingBranchError(f'Branch {branch} does not exist in {package}')
+            checkout_unborn_repository_to_remote_branch(repository, branch, remote_branch)
+            return
+
+        if repository.is_dirty(untracked_files=True):
+            raise RepositoryDirtyError(
+                f'Repository for {package} has local changes; refusing to switch branches automatically.'
+            )
+
         logging.info(f'Checking out branch {branch} in {package}')
-        repository.git.checkout('-f', branch)
-    except InvalidGitRepositoryError:
+        if branch in repository.heads:
+            repository.heads[branch].checkout()
+            return
+
+        if remote_branch:
+            local_branch = repository.create_head(branch, remote_branch.commit)
+            local_branch.set_tracking_branch(remote_branch)
+            local_branch.checkout()
+            return
+
+        raise MissingBranchError(f'Branch {branch} does not exist in {package}')
+    except (InvalidGitRepositoryError, GitCommandError):
         logging.info(f'Branch {branch} does not exist in {package}')
         raise MissingBranchError(f'Branch {branch} does not exist in {package}')

--- a/scripts/git_commands.py
+++ b/scripts/git_commands.py
@@ -114,6 +114,9 @@ def fetch_tags(repository: Repo):
     repository.git.fetch('--tags')
     logging.info('Fetched remote tags')
 
+def has_tag(repository: Repo, tag_name: str) -> bool:
+    return any(tag.name == tag_name for tag in repository.tags)
+
 def fetch_remote(repository: Repo):
     repository.git.fetch('origin')
     logging.info('Fetched remote branches')

--- a/scripts/git_shell.py
+++ b/scripts/git_shell.py
@@ -6,23 +6,23 @@ class PackageBranchExistError(Exception):
 
 
 def get_current_git_branch(cwd=None):
-    current_branch = execute_shell_command('git branch --show-current', cwd=cwd, capture_output=True)
+    current_branch = execute_shell_command(['git', 'branch', '--show-current'], cwd=cwd, capture_output=True)
     return current_branch
 
 def fetch_repo(cwd):
-    execute_shell_command('git fetch', cwd)
+    execute_shell_command(['git', 'fetch'], cwd)
 
 def create_or_update_branch(cwd, branch: str):
     fetch_repo(cwd)
-    branches = execute_shell_command('git branch -a', cwd=cwd, capture_output=True)
+    branches = execute_shell_command(['git', 'branch', '-a'], cwd=cwd, capture_output=True)
     if f'remotes/origin/{branch}' in branches:
-        execute_shell_command(f'git push -f', cwd)
+        execute_shell_command(['git', 'push', '-f'], cwd)
     else:
-        execute_shell_command(f'git checkout -b {branch}', cwd)
+        execute_shell_command(['git', 'checkout', '-b', branch], cwd)
 
 def commit_changes(cwd, message='Release changes'):
-    execute_shell_command('git add .', cwd)
-    execute_shell_command(f'git commit -am "{message}"', cwd)
+    execute_shell_command(['git', 'add', '.'], cwd)
+    execute_shell_command(['git', 'commit', '-am', message], cwd)
 
 def push_changes(cwd, new_branch: str):
-    execute_shell_command(f'git push origin {new_branch}', cwd)
+    execute_shell_command(['git', 'push', 'origin', new_branch], cwd)

--- a/scripts/github.py
+++ b/scripts/github.py
@@ -1,16 +1,46 @@
 from shell import execute_shell_command
 
 
+def check_auth(cwd=None):
+    execute_shell_command(['gh', 'auth', 'status'], cwd=cwd)
+
+
 def create_merge_request(cwd, base_branch: str, new_branch: str, release_name: str):
-    execute_shell_command(f'gh pr create --base {base_branch} --head {new_branch} --title "Release {release_name}" --body "Automated release PR for {release_name}"', cwd)
+    execute_shell_command([
+        'gh', 'pr', 'create',
+        '--base', base_branch,
+        '--head', new_branch,
+        '--title', f'Release {release_name}',
+        '--body', f'Automated release PR for {release_name}'
+    ], cwd)
 
 def merge_pr(cwd, branch: str, release_name: str):
-    execute_shell_command(f'gh pr merge {branch} --squash --delete-branch --subject "Merge Release {release_name}"', cwd)
+    execute_shell_command([
+        'gh', 'pr', 'merge', branch,
+        '--squash',
+        '--delete-branch',
+        '--subject', f'Merge Release {release_name}'
+    ], cwd)
 
-def create_release(cwd, branch: str, release_name: str):
-    execute_shell_command(f'gh release create {release_name} --target {branch} --title "{release_name}" --notes "Release notes for {release_name}"', cwd)
+def create_release(cwd, branch: str, release_name: str, notes: str = ""):
+    cmd = ['gh', 'release', 'create', release_name, '--target', branch, '--title', release_name]
+    if notes:
+        cmd.extend(['--notes', notes])
+    execute_shell_command(cmd, cwd)
 
 def check_for_open_prs(cwd, branch: str):
-    prs = execute_shell_command(f'gh pr list --state open --head {branch}', cwd=cwd, capture_output=True)
+    prs = execute_shell_command(
+        ['gh', 'pr', 'list', '--state', 'open', '--head', branch],
+        cwd=cwd,
+        capture_output=True
+    )
     return bool(prs)
 
+
+def check_for_merged_prs(cwd, branch: str):
+    prs = execute_shell_command(
+        ['gh', 'pr', 'list', '--state', 'merged', '--head', branch],
+        cwd=cwd,
+        capture_output=True
+    )
+    return bool(prs)

--- a/scripts/init.py
+++ b/scripts/init.py
@@ -5,32 +5,66 @@ import os, logging, argparse
 from packages import read_packages
 from packagist import get_repository_link
 from git_shell import get_current_git_branch
-from git_commands import checkout, init_repository, MissingBranchError
+from git_commands import checkout, init_repository, MissingBranchError, RepositoryDirtyError, \
+    create_branch_from_remote, MissingBaseBranchError
 
 logging.basicConfig(level=logging.INFO)
 
-def main(branch, config_file):
+def main(branch, config_file, from_branch=None, push_missing_branches=False):
     if not config_file:
         raise ValueError('No config file specified.')
 
     packages = read_packages(config_file)
 
     packages_with_missing_branches = []
+    packages_with_missing_base_branches = []
+    packages_with_dirty_repositories = []
     for package, folder in packages.items():
-        repository = init_repository(folder, get_repository_link(package))
+        repository = init_repository(folder, get_repository_link(package), branch)
         try:
             checkout(repository, package, branch)
         except MissingBranchError:
-            packages_with_missing_branches.append(package)
+            if from_branch:
+                try:
+                    if push_missing_branches:
+                        create_branch_from_remote(
+                            repository,
+                            package,
+                            branch,
+                            from_branch,
+                            True
+                        )
+                    else:
+                        try:
+                            checkout(repository, package, from_branch)
+                        except MissingBranchError:
+                            packages_with_missing_base_branches.append(package)
+                except MissingBaseBranchError:
+                    packages_with_missing_base_branches.append(package)
+                except RepositoryDirtyError:
+                    packages_with_dirty_repositories.append(package)
+                except Exception as e:
+                    logging.error(e)
+                    packages_with_missing_branches.append(package)
+            else:
+                packages_with_missing_branches.append(package)
+        except RepositoryDirtyError:
+            packages_with_dirty_repositories.append(package)
         except Exception as e:
             logging.error(e)
 
     if 0 < len(packages_with_missing_branches):
         print(f'The following packages do not have the {branch} branch: {packages_with_missing_branches}')
+    if 0 < len(packages_with_missing_base_branches):
+        print(f'The following packages do not have the fallback {from_branch} branch: {packages_with_missing_base_branches}')
+    if 0 < len(packages_with_dirty_repositories):
+        print(f'The following packages have local changes and were not switched to {branch}: {packages_with_dirty_repositories}')
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Script to manage git multi-repositories.')
     parser.add_argument('--config', '-c', required=True, help='Path to the config json file')
+    parser.add_argument('--from-branch', type=str, help='Fallback remote branch to create the target branch from if it does not exist')
+    parser.add_argument('--push-missing-branches', action='store_true', help='Push newly created missing branches to origin')
     parser.add_argument('--debug', '-d', action='store_true', help='Enable debug logging')
     app_args = parser.parse_args()
 
@@ -41,4 +75,9 @@ if __name__ == '__main__':
     working_dir = os.path.dirname(config_file_path)
     os.chdir(working_dir)
 
-    main(get_current_git_branch(), config_file_path)
+    main(
+        get_current_git_branch(),
+        config_file_path,
+        app_args.from_branch,
+        app_args.push_missing_branches
+    )

--- a/scripts/merge_src_composer_dependencies.py
+++ b/scripts/merge_src_composer_dependencies.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+from pathlib import Path
+
+
+def load_json(path: Path) -> dict:
+    with path.open() as file:
+        return json.load(file)
+
+
+def collect_src_package_names(src_dir: Path) -> set[str]:
+    package_names = set()
+
+    for composer_file in src_dir.rglob('composer.json'):
+        package_name = load_json(composer_file).get('name')
+        if package_name:
+            package_names.add(package_name)
+
+    return package_names
+
+
+def collect_dependencies(src_dir: Path, internal_packages: set[str], include_internal: bool) -> dict[str, dict[str, str]]:
+    dependencies = {
+        'require': {},
+        'require-dev': {},
+    }
+
+    for composer_file in sorted(src_dir.rglob('composer.json')):
+        package = load_json(composer_file)
+
+        for section in dependencies:
+            for name, constraint in package.get(section, {}).items():
+                if not include_internal and name in internal_packages:
+                    continue
+
+                dependencies[section].setdefault(name, str(constraint))
+
+    return dependencies
+
+
+def merge_dependencies(root_composer: dict, dependencies: dict[str, dict[str, str]]) -> dict[str, list[str]]:
+    changes = {
+        'added': [],
+        'kept': [],
+        'conflicts': [],
+    }
+
+    for section, packages in dependencies.items():
+        root_composer.setdefault(section, {})
+
+        for name, constraint in sorted(packages.items()):
+            current_constraint = root_composer[section].get(name)
+
+            if current_constraint is None:
+                root_composer[section][name] = constraint
+                changes['added'].append(f'{section}: {name} {constraint}')
+                continue
+
+            if current_constraint == constraint:
+                changes['kept'].append(f'{section}: {name} {constraint}')
+                continue
+
+            changes['conflicts'].append(
+                f'{section}: {name} root has {current_constraint}, src has {constraint}'
+            )
+
+    return changes
+
+
+def write_json(path: Path, data: dict) -> None:
+    path.write_text(json.dumps(data, indent=4, ensure_ascii=False) + '\n')
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description='Merge dependencies from src/**/composer.json files into the root composer.json.'
+    )
+    parser.add_argument('--root', default='composer.json', help='Path to the root composer.json file')
+    parser.add_argument('--src', default='src', help='Path to the src directory')
+    parser.add_argument('--include-internal', action='store_true', help='Also merge dependencies on packages found in src')
+    parser.add_argument('--dry-run', action='store_true', help='Print changes without writing composer.json')
+    args = parser.parse_args()
+
+    root_composer_file = Path(args.root)
+    src_dir = Path(args.src)
+
+    root_composer = load_json(root_composer_file)
+    internal_packages = collect_src_package_names(src_dir)
+    dependencies = collect_dependencies(src_dir, internal_packages, args.include_internal)
+    changes = merge_dependencies(root_composer, dependencies)
+
+    for change_type in ('added', 'conflicts'):
+        for change in changes[change_type]:
+            print(f'{change_type}: {change}')
+
+    if not args.dry_run:
+        write_json(root_composer_file, root_composer)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/packagist.py
+++ b/scripts/packagist.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import requests
 
 def to_ssh(func):

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,17 +1,229 @@
 #!/usr/bin/env python3
 
-import os, argparse, logging
+import os, argparse, logging, shutil, subprocess, sys, re
 
 from git import InvalidGitRepositoryError
 
-from github import create_merge_request, merge_pr, create_release, check_for_open_prs
-from git_shell import get_current_git_branch
+from github import create_merge_request, merge_pr, create_release, check_for_open_prs, check_for_merged_prs, check_auth
 from packages import read_packages
 from git_commands import create_or_update_branch, get_repository, commit_changes, NothingToCommitException, push_changes, \
-    BranchNotActiveError, get_changes_to_commit
+    get_changes_to_commit, fetch_tags, fetch_remote, has_remote_branch
 from shell import ShellError
 
 logging.basicConfig(level=logging.INFO)
+
+def check_gh_installed() -> bool:
+    """Verify that the GitHub CLI is installed."""
+    if shutil.which("gh") is None:
+        logging.error("GitHub CLI 'gh' not found")
+        return False
+    try:
+        subprocess.run(["gh", "--version"], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except Exception as e:
+        logging.error(f"GitHub CLI check failed: {e}")
+        return False
+    return True
+
+def validate_gh_access() -> bool:
+    try:
+        check_auth()
+    except ShellError as e:
+        logging.error(f'GitHub CLI authentication check failed: {e}')
+        return False
+    return True
+
+def compute_next_version(repo):
+    """Return the next patch version based on existing tags."""
+    versions = []
+    pattern = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+    for tag in repo.tags:
+        m = pattern.match(tag.name)
+        if m:
+            versions.append(tuple(map(int, m.groups())))
+    if versions:
+        major, minor, patch = sorted(versions)[-1]
+    else:
+        major, minor, patch = 0, 0, 0
+    patch += 1
+    return f"v{major}.{minor}.{patch}"
+
+def collect_release_notes(repo, base_branch: str) -> str:
+    """Collect commit subjects since the last release tag.
+
+    The release flow uses squash merges, so release notes need to be based on
+    the commit subjects present on the base branch rather than merge commits.
+    """
+    tags = [t for t in repo.tags if t.name.startswith("v")]
+    if tags:
+        last_tag = sorted(tags, key=lambda t: t.commit.committed_datetime)[-1]
+        rev_range = f"{last_tag.name}..{base_branch}"
+    else:
+        rev_range = base_branch
+    commits = list(repo.iter_commits(rev_range))
+    notes = []
+    for commit in reversed(commits):
+        subject = commit.message.splitlines()[0].strip()
+        if subject:
+            notes.append(subject)
+    return "\n".join(notes)
+
+
+def has_unreleased_commits(repo, base_branch: str) -> bool:
+    tags = [t for t in repo.tags if t.name.startswith("v")]
+    if tags:
+        last_tag = sorted(tags, key=lambda t: t.commit.committed_datetime)[-1]
+        rev_range = f"{last_tag.name}..{base_branch}"
+    else:
+        rev_range = base_branch
+
+    return any(True for _ in repo.iter_commits(rev_range, max_count=1))
+
+
+def preflight_branches(packages: dict[str, str], release_branch: str, base_branch: str, merge: bool) -> list[str]:
+    failed_packages = []
+
+    for package, folder in packages.items():
+        original_directory = os.getcwd()
+        os.chdir(folder)
+        try:
+            repo = get_repository('.')
+            fetch_remote(repo)
+
+            if not has_remote_branch(repo, base_branch):
+                logging.error(f'Remote base branch `{base_branch}` does not exist in {package}')
+                failed_packages.append(package)
+                continue
+
+            if has_remote_branch(repo, release_branch):
+                continue
+
+            if merge and check_for_merged_prs('.', release_branch):
+                logging.info(
+                    f'Remote release branch `{release_branch}` is absent in {package}, '
+                    'but a merged PR exists, allowing release recovery'
+                )
+                continue
+
+            logging.error(f'Remote release branch `{release_branch}` does not exist in {package}')
+            failed_packages.append(package)
+        except (ShellError, InvalidGitRepositoryError) as e:
+            logging.error(f'Preflight failed for {package}: {e}')
+            failed_packages.append(package)
+        finally:
+            os.chdir(original_directory)
+
+    return failed_packages
+
+
+def preflight_clean_worktrees(packages: dict[str, str]) -> list[str]:
+    failed_packages = []
+
+    for package, folder in packages.items():
+        original_directory = os.getcwd()
+        os.chdir(folder)
+        try:
+            repo = get_repository('.')
+            if repo.is_dirty(untracked_files=True):
+                logging.error(f'Repository for {package} has local changes or untracked files')
+                failed_packages.append(package)
+        except InvalidGitRepositoryError as e:
+            logging.error(f'Worktree preflight failed for {package}: {e}')
+            failed_packages.append(package)
+        finally:
+            os.chdir(original_directory)
+
+    return failed_packages
+
+
+def plan_package_action(
+    package: str,
+    folder: str,
+    release_branch: str,
+    base_branch: str,
+    merge: bool,
+    do_not_release: bool,
+    skip_release: bool
+) -> tuple[str, bool]:
+    original_directory = os.getcwd()
+    os.chdir(folder)
+    try:
+        repo = get_repository('.')
+        fetch_remote(repo)
+
+        if not has_remote_branch(repo, base_branch):
+            return f'blocked: remote base branch `{base_branch}` is missing', True
+
+        release_branch_exists = has_remote_branch(repo, release_branch)
+
+        if merge:
+            fetch_tags(repo)
+            has_open_pr = check_for_open_prs('.', release_branch)
+            has_merged_pr = check_for_merged_prs('.', release_branch)
+
+            if not release_branch_exists and not has_merged_pr:
+                return f'blocked: remote release branch `{release_branch}` is missing', True
+
+            if has_open_pr:
+                release_version = compute_next_version(repo)
+                if skip_release:
+                    return f'would merge PR `{release_branch}` and skip release `{release_version}`', False
+                if do_not_release:
+                    return f'would merge PR `{release_branch}` without creating a release', False
+                return f'would merge PR `{release_branch}` and create release `{release_version}`', False
+
+            if has_merged_pr:
+                if not has_unreleased_commits(repo, base_branch):
+                    return f'noop: merged PR already released on `{base_branch}`', False
+
+                release_version = compute_next_version(repo)
+                if skip_release:
+                    return f'would skip creating missing release `{release_version}` for merged PR `{release_branch}`', False
+                if do_not_release:
+                    return f'would not create missing release `{release_version}` because `--no-release` is set', False
+                return f'would create missing release `{release_version}` for merged PR `{release_branch}`', False
+
+            return f'noop: no open or merged PR for `{release_branch}`', False
+
+        if repo.is_dirty(untracked_files=True):
+            return 'blocked: local changes or untracked files are present', True
+
+        if release_branch_exists:
+            if check_for_open_prs('.', release_branch):
+                return f'noop: release branch `{release_branch}` and its PR already exist', False
+            return f'noop: release branch `{release_branch}` exists remotely but worktree is clean', False
+
+        return 'noop: worktree is clean; nothing would be committed', False
+    except (ShellError, InvalidGitRepositoryError) as e:
+        return f'blocked: unable to inspect repository state ({e})', True
+    finally:
+        os.chdir(original_directory)
+
+
+def preview_actions(
+    packages: dict[str, str],
+    release_branch: str,
+    base_branch: str,
+    merge: bool,
+    do_not_release: bool,
+    skip_release: bool
+) -> list[str]:
+    failed_packages = []
+
+    for package, folder in packages.items():
+        action, is_blocked = plan_package_action(
+            package,
+            folder,
+            release_branch,
+            base_branch,
+            merge,
+            do_not_release,
+            skip_release
+        )
+        logging.info(f'[{package}] {action}')
+        if is_blocked:
+            failed_packages.append(package)
+
+    return failed_packages
 
 def main(
     release_name: str,
@@ -20,13 +232,43 @@ def main(
     config_file: str,
     merge: bool,
     do_not_release: bool,
-    skip_release: bool
-):
+    skip_release: bool,
+    dry_run: bool = False,
+    status: bool = False
+) -> list[str]:
+    if not check_gh_installed():
+        sys.exit(1)
+    if not validate_gh_access():
+        sys.exit(1)
     if not config_file:
         raise ValueError('No config file specified.')
 
     logging.info(f'Preparing release `{release_name}` on branch `{branch}`')
     packages = read_packages(config_file)
+
+    if dry_run or status:
+        failed_packages = preview_actions(
+            packages,
+            branch,
+            base_branch,
+            merge,
+            do_not_release,
+            skip_release
+        )
+        if failed_packages:
+            logging.error(f'Preview found blocked packages: {failed_packages}')
+        return failed_packages
+
+    failed_packages = preflight_branches(packages, branch, base_branch, merge)
+    if failed_packages:
+        logging.error(f'Branch preflight failed for packages: {failed_packages}')
+        return failed_packages
+
+    if not merge:
+        failed_packages = preflight_clean_worktrees(packages)
+        if failed_packages:
+            logging.error(f'Worktree preflight failed for packages: {failed_packages}')
+            return failed_packages
 
     failed_packages = []
     for package, folder in packages.items():
@@ -35,12 +277,34 @@ def main(
         os.chdir(folder)
         try:
             if merge:
-                if check_for_open_prs('.', branch):
-                    merge_pr('.', branch, release_name)
-                elif skip_release:
+                repo = get_repository('.')
+                fetch_tags(repo)
+                has_open_pr = check_for_open_prs('.', branch)
+                has_merged_pr = check_for_merged_prs('.', branch)
+
+                if not has_open_pr and not has_merged_pr:
+                    logging.info(f'No open or merged PR for branch `{branch}` in {package}, skipping merge/release')
                     continue
+
+                if has_open_pr:
+                    release_version = compute_next_version(repo)
+                    notes = collect_release_notes(repo, base_branch)
+                    merge_pr('.', branch, release_version)
+                else:
+                    if not has_unreleased_commits(repo, base_branch):
+                        logging.info(f'No unreleased commits found on `{base_branch}` in {package}, skipping release')
+                        continue
+
+                    release_version = compute_next_version(repo)
+                    notes = collect_release_notes(repo, base_branch)
+                    logging.info(f'PR for branch `{branch}` is already merged in {package}; creating missing release `{release_version}`')
+
+                if skip_release:
+                    logging.info(f'Release creation skipped for {package}')
+                    continue
+
                 if not do_not_release:
-                    create_release('.', base_branch, release_name)
+                    create_release('.', base_branch, release_version, notes)
             else:
                 repo = get_repository('.')
                 files_to_add, files_to_remove = get_changes_to_commit(repo)
@@ -59,9 +323,6 @@ def main(
         except ShellError as e:
             logging.error(f'Shell error: {e}')
             failed_packages.append(package)
-        except BranchNotActiveError:
-            logging.warning(f'Branch does exist but is not active. Please manually switch to branch `{branch}`')
-            failed_packages.append(package)
         except InvalidGitRepositoryError:
             logging.error(f"Invalid git repository {folder}")
             failed_packages.append(package)
@@ -73,27 +334,46 @@ def main(
     if 0 < len(failed_packages):
         logging.error(f'The following packages has not been released and should be processed manually: {failed_packages}')
 
+    return failed_packages
+
        
-if __name__ == '__main__':
+def run_cli(args=None):
     parser = argparse.ArgumentParser(description='Release script to handle package versions.')
     parser.add_argument('--config', '-c', required=True, help='Path to the config json file')
     parser.add_argument('--merge', action='store_true', help='Merge all open merge requests and create releases')
-    parser.add_argument('--no-release', action='store_true', help='Don\'t create any release')
+    parser.add_argument('--no-release', action='store_true', help="Don't create any release")
     parser.add_argument('--skip-release', '-s', action='store_true', help='Skip creating a release if no PR opened')
+    parser.add_argument('--dry-run', action='store_true', help='Show planned actions without mutating repositories or GitHub')
+    parser.add_argument('--status', action='store_true', help='Show per-package release status without mutating anything')
     parser.add_argument('--base-branch', '-b', type=str, help='Base branch')
+    parser.add_argument('--release-branch', '-r', type=str, help='Release branch to prepare or merge')
     parser.add_argument('release_name', type=str, help='Name of the release')
-    app_args = parser.parse_args()
+    app_args = parser.parse_args(args)
+
+    if not app_args.base_branch:
+        parser.error('--base-branch is required')
+    if not app_args.release_branch:
+        parser.error('--release-branch is required')
 
     config_file_path = os.path.abspath(app_args.config)
     working_dir = os.path.dirname(config_file_path)
     os.chdir(working_dir)
 
-    main(
+    failed_packages = main(
         app_args.release_name,
-        get_current_git_branch(),
+        app_args.release_branch,
         app_args.base_branch,
         config_file_path,
         app_args.merge,
         app_args.no_release,
-        app_args.skip_release
+        app_args.skip_release,
+        app_args.dry_run,
+        app_args.status
     )
+
+    if failed_packages:
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    run_cli()

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -7,7 +7,7 @@ from git import InvalidGitRepositoryError
 from github import create_merge_request, merge_pr, create_release, check_for_open_prs, check_for_merged_prs, check_auth
 from packages import read_packages
 from git_commands import create_or_update_branch, get_repository, commit_changes, NothingToCommitException, push_changes, \
-    get_changes_to_commit, fetch_tags, fetch_remote, has_remote_branch
+    get_changes_to_commit, fetch_tags, fetch_remote, has_remote_branch, has_tag
 from shell import ShellError
 
 logging.basicConfig(level=logging.INFO)
@@ -135,9 +135,34 @@ def preflight_clean_worktrees(packages: dict[str, str]) -> list[str]:
     return failed_packages
 
 
+def preflight_release_tags(packages: dict[str, str], release_name: str, merge: bool) -> list[str]:
+    failed_packages = []
+
+    if not merge:
+        return failed_packages
+
+    for package, folder in packages.items():
+        original_directory = os.getcwd()
+        os.chdir(folder)
+        try:
+            repo = get_repository('.')
+            fetch_tags(repo)
+            if has_tag(repo, release_name):
+                logging.error(f'Release tag `{release_name}` already exists in {package}')
+                failed_packages.append(package)
+        except (ShellError, InvalidGitRepositoryError) as e:
+            logging.error(f'Tag preflight failed for {package}: {e}')
+            failed_packages.append(package)
+        finally:
+            os.chdir(original_directory)
+
+    return failed_packages
+
+
 def plan_package_action(
     package: str,
     folder: str,
+    release_name: str,
     release_branch: str,
     base_branch: str,
     merge: bool,
@@ -157,6 +182,8 @@ def plan_package_action(
 
         if merge:
             fetch_tags(repo)
+            if has_tag(repo, release_name):
+                return f'blocked: release tag `{release_name}` already exists', True
             has_open_pr = check_for_open_prs('.', release_branch)
             has_merged_pr = check_for_merged_prs('.', release_branch)
 
@@ -201,6 +228,7 @@ def plan_package_action(
 
 def preview_actions(
     packages: dict[str, str],
+    release_name: str,
     release_branch: str,
     base_branch: str,
     merge: bool,
@@ -213,6 +241,7 @@ def preview_actions(
         action, is_blocked = plan_package_action(
             package,
             folder,
+            release_name,
             release_branch,
             base_branch,
             merge,
@@ -249,6 +278,7 @@ def main(
     if dry_run or status:
         failed_packages = preview_actions(
             packages,
+            release_name,
             branch,
             base_branch,
             merge,
@@ -262,6 +292,11 @@ def main(
     failed_packages = preflight_branches(packages, branch, base_branch, merge)
     if failed_packages:
         logging.error(f'Branch preflight failed for packages: {failed_packages}')
+        return failed_packages
+
+    failed_packages = preflight_release_tags(packages, release_name, merge)
+    if failed_packages:
+        logging.error(f'Tag preflight failed for packages: {failed_packages}')
         return failed_packages
 
     if not merge:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -7,7 +7,7 @@ from git import InvalidGitRepositoryError
 from github import create_merge_request, merge_pr, create_release, check_for_open_prs, check_for_merged_prs, check_auth
 from packages import read_packages
 from git_commands import create_or_update_branch, get_repository, commit_changes, NothingToCommitException, push_changes, \
-    get_changes_to_commit, fetch_tags, fetch_remote, has_remote_branch, has_tag
+    get_changes_to_commit, fetch_tags, fetch_remote, has_remote_branch, has_tag, checkout
 from shell import ShellError
 
 logging.basicConfig(level=logging.INFO)
@@ -79,7 +79,13 @@ def has_unreleased_commits(repo, base_branch: str) -> bool:
     return any(True for _ in repo.iter_commits(rev_range, max_count=1))
 
 
-def preflight_branches(packages: dict[str, str], release_branch: str, base_branch: str, merge: bool) -> list[str]:
+def preflight_branches(
+    packages: dict[str, str],
+    release_branch: str | None,
+    base_branch: str,
+    merge: bool,
+    release_current: bool
+) -> list[str]:
     failed_packages = []
 
     for package, folder in packages.items():
@@ -92,6 +98,9 @@ def preflight_branches(packages: dict[str, str], release_branch: str, base_branc
             if not has_remote_branch(repo, base_branch):
                 logging.error(f'Remote base branch `{base_branch}` does not exist in {package}')
                 failed_packages.append(package)
+                continue
+
+            if release_current:
                 continue
 
             if has_remote_branch(repo, release_branch):
@@ -135,10 +144,10 @@ def preflight_clean_worktrees(packages: dict[str, str]) -> list[str]:
     return failed_packages
 
 
-def preflight_release_tags(packages: dict[str, str], release_name: str, merge: bool) -> list[str]:
+def preflight_release_tags(packages: dict[str, str], release_name: str, merge: bool, release_current: bool) -> list[str]:
     failed_packages = []
 
-    if not merge:
+    if not merge and not release_current:
         return failed_packages
 
     for package, folder in packages.items():
@@ -163,9 +172,11 @@ def plan_package_action(
     package: str,
     folder: str,
     release_name: str,
-    release_branch: str,
+    release_branch: str | None,
     base_branch: str,
     merge: bool,
+    release_current: bool,
+    force_release: bool,
     do_not_release: bool,
     skip_release: bool
 ) -> tuple[str, bool]:
@@ -178,7 +189,19 @@ def plan_package_action(
         if not has_remote_branch(repo, base_branch):
             return f'blocked: remote base branch `{base_branch}` is missing', True
 
-        release_branch_exists = has_remote_branch(repo, release_branch)
+        release_branch_exists = has_remote_branch(repo, release_branch) if release_branch else False
+
+        if release_current:
+            fetch_tags(repo)
+            if has_tag(repo, release_name):
+                return f'blocked: release tag `{release_name}` already exists', True
+            if repo.is_dirty(untracked_files=True):
+                return 'blocked: local changes or untracked files are present', True
+            if force_release:
+                return f'would force-create release `{release_name}` from `{base_branch}`', False
+            if not has_unreleased_commits(repo, base_branch):
+                return f'noop: no unreleased commits on `{base_branch}`', False
+            return f'would create release `{release_name}` from `{base_branch}`', False
 
         if merge:
             fetch_tags(repo)
@@ -229,9 +252,11 @@ def plan_package_action(
 def preview_actions(
     packages: dict[str, str],
     release_name: str,
-    release_branch: str,
+    release_branch: str | None,
     base_branch: str,
     merge: bool,
+    release_current: bool,
+    force_release: bool,
     do_not_release: bool,
     skip_release: bool
 ) -> list[str]:
@@ -245,6 +270,8 @@ def preview_actions(
             release_branch,
             base_branch,
             merge,
+            release_current,
+            force_release,
             do_not_release,
             skip_release
         )
@@ -256,10 +283,12 @@ def preview_actions(
 
 def main(
     release_name: str,
-    branch: str,
+    branch: str | None,
     base_branch: str,
     config_file: str,
     merge: bool,
+    release_current: bool,
+    force_release: bool,
     do_not_release: bool,
     skip_release: bool,
     dry_run: bool = False,
@@ -272,7 +301,8 @@ def main(
     if not config_file:
         raise ValueError('No config file specified.')
 
-    logging.info(f'Preparing release `{release_name}` on branch `{branch}`')
+    target_ref = base_branch if release_current else branch
+    logging.info(f'Preparing release `{release_name}` on branch `{target_ref}`')
     packages = read_packages(config_file)
 
     if dry_run or status:
@@ -282,6 +312,8 @@ def main(
             branch,
             base_branch,
             merge,
+            release_current,
+            force_release,
             do_not_release,
             skip_release
         )
@@ -289,17 +321,17 @@ def main(
             logging.error(f'Preview found blocked packages: {failed_packages}')
         return failed_packages
 
-    failed_packages = preflight_branches(packages, branch, base_branch, merge)
+    failed_packages = preflight_branches(packages, branch, base_branch, merge, release_current)
     if failed_packages:
         logging.error(f'Branch preflight failed for packages: {failed_packages}')
         return failed_packages
 
-    failed_packages = preflight_release_tags(packages, release_name, merge)
+    failed_packages = preflight_release_tags(packages, release_name, merge, release_current)
     if failed_packages:
         logging.error(f'Tag preflight failed for packages: {failed_packages}')
         return failed_packages
 
-    if not merge:
+    if not merge or release_current:
         failed_packages = preflight_clean_worktrees(packages)
         if failed_packages:
             logging.error(f'Worktree preflight failed for packages: {failed_packages}')
@@ -311,7 +343,16 @@ def main(
         original_directory = os.getcwd()
         os.chdir(folder)
         try:
-            if merge:
+            if release_current:
+                repo = get_repository('.')
+                fetch_tags(repo)
+                if not force_release and not has_unreleased_commits(repo, base_branch):
+                    logging.info(f'No unreleased commits found on `{base_branch}` in {package}, skipping release')
+                    continue
+                checkout(repo, package, base_branch)
+                notes = collect_release_notes(repo, base_branch)
+                create_release('.', base_branch, release_name, notes)
+            elif merge:
                 repo = get_repository('.')
                 fetch_tags(repo)
                 has_open_pr = check_for_open_prs('.', branch)
@@ -376,6 +417,8 @@ def run_cli(args=None):
     parser = argparse.ArgumentParser(description='Release script to handle package versions.')
     parser.add_argument('--config', '-c', required=True, help='Path to the config json file')
     parser.add_argument('--merge', action='store_true', help='Merge all open merge requests and create releases')
+    parser.add_argument('--release-current', action='store_true', help='Create releases directly from the current base branch without PRs')
+    parser.add_argument('--force-release', action='store_true', help='Force release creation in --release-current mode even if no unreleased commits are detected')
     parser.add_argument('--no-release', action='store_true', help="Don't create any release")
     parser.add_argument('--skip-release', '-s', action='store_true', help='Skip creating a release if no PR opened')
     parser.add_argument('--dry-run', action='store_true', help='Show planned actions without mutating repositories or GitHub')
@@ -387,8 +430,18 @@ def run_cli(args=None):
 
     if not app_args.base_branch:
         parser.error('--base-branch is required')
-    if not app_args.release_branch:
+    if not app_args.release_current and not app_args.release_branch:
         parser.error('--release-branch is required')
+    if app_args.release_current and app_args.release_branch:
+        parser.error('--release-branch cannot be used with --release-current')
+    if app_args.release_current and app_args.merge:
+        parser.error('--merge cannot be used with --release-current')
+    if app_args.release_current and app_args.skip_release:
+        parser.error('--skip-release cannot be used with --release-current')
+    if app_args.release_current and app_args.no_release:
+        parser.error('--no-release cannot be used with --release-current')
+    if app_args.force_release and not app_args.release_current:
+        parser.error('--force-release can only be used with --release-current')
 
     config_file_path = os.path.abspath(app_args.config)
     working_dir = os.path.dirname(config_file_path)
@@ -400,6 +453,8 @@ def run_cli(args=None):
         app_args.base_branch,
         config_file_path,
         app_args.merge,
+        app_args.release_current,
+        app_args.force_release,
         app_args.no_release,
         app_args.skip_release,
         app_args.dry_run,

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,2 +1,0 @@
-GitPython~=3.1.43
-requests~=2.31.0

--- a/scripts/shell.py
+++ b/scripts/shell.py
@@ -1,4 +1,7 @@
-import os, logging, subprocess
+import logging
+import os
+import shlex
+import subprocess
 
 class ShellError(Exception):
     pass
@@ -6,13 +9,21 @@ class ShellError(Exception):
 def execute_shell_command(cmd, cwd=None, capture_output=False):
     if cwd is None:
         cwd = os.getcwd()
-    logging.info(f'Running a command:"{cmd}" in a working directory {cwd}')
+    args = shlex.split(cmd) if isinstance(cmd, str) else list(cmd)
+    logging.info(f'Running command: {shlex.join(args)} in working directory {cwd}')
     try:
-        result = subprocess.run(cmd, check=True, cwd=cwd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        result = subprocess.run(
+            args,
+            check=True,
+            cwd=cwd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True
+        )
         logging.info(f'STDOUT: {result.stdout}')
         if capture_output:
-            return result.stdout.strip()  # Return the stdout if capture_output is True
+            return result.stdout.strip()
     except subprocess.CalledProcessError as e:
-        logging.error(f'Command "{cmd}" failed with error: {e}')
+        logging.error(f'Command "{shlex.join(args)}" failed with error: {e}')
         logging.error(f'STDERR: {e.stderr}')
-        raise ShellError(f'Command "{cmd}" failed with error: {e}')
+        raise ShellError(f'Command "{shlex.join(args)}" failed with error: {e.stderr.strip() or e}')

--- a/src/Micro/Plugin/HttpRoadrunner/composer.json
+++ b/src/Micro/Plugin/HttpRoadrunner/composer.json
@@ -15,7 +15,7 @@
         "micro/plugin-event-emitter": "^1.6",
         "micro/plugin-http-core": "^1.6",
         "nyholm/psr7": "^1.8",
-        "spiral/roadrunner": "^2.0",
+        "spiral/roadrunner": "^v2025.1.13",
         "symfony/psr-http-message-bridge": "^2.3"
     },
     "minimum-stability": "dev",

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+scripts_dir = Path(__file__).resolve().parents[2] / 'scripts'
+sys.path.insert(0, str(scripts_dir))

--- a/tests/python/test_git_commands.py
+++ b/tests/python/test_git_commands.py
@@ -1,0 +1,251 @@
+import os
+from git import Repo
+import pytest
+import git_commands
+
+
+def create_remote_repo(tmp_path):
+    remote_path = tmp_path / "remote"
+    repo = Repo.init(remote_path)
+    (remote_path / "file.txt").write_text("init")
+    repo.index.add(["file.txt"])
+    repo.index.commit("init")
+    repo.create_head("2.x")
+    return repo
+
+
+def test_init_repository_fetch_and_reset(tmp_path):
+    remote_repo = create_remote_repo(tmp_path)
+    local_dir = tmp_path / "local"
+    repo = git_commands.init_repository(str(local_dir), str(remote_repo.working_tree_dir), "2.x")
+    assert repo.remotes.origin.url == str(remote_repo.working_tree_dir)
+    assert "2.x" in repo.heads
+    assert repo.heads["2.x"].commit.hexsha == remote_repo.refs["2.x"].commit.hexsha
+
+
+def test_init_repository_does_not_reset_local_changes(tmp_path):
+    remote_repo = create_remote_repo(tmp_path)
+    local_dir = tmp_path / "local"
+    repo = git_commands.init_repository(str(local_dir), str(remote_repo.working_tree_dir), "2.x")
+    repo.heads["2.x"].checkout()
+
+    file_path = local_dir / "file.txt"
+    file_path.write_text("local change")
+
+    git_commands.init_repository(str(local_dir), str(remote_repo.working_tree_dir), "2.x")
+
+    assert file_path.read_text() == "local change"
+
+
+def test_update_repository_remote_link(tmp_path):
+    repo = Repo.init(tmp_path / "repo")
+    repo.create_remote("origin", "old")
+    git_commands.update_repository_remote_link(repo, "origin", "new")
+    assert repo.remotes.origin.url == "new"
+
+
+def test_fetch_tags(tmp_path):
+    remote_path = tmp_path / "remote.git"
+    remote_repo = Repo.init(remote_path, bare=True)
+    source_path = tmp_path / "source"
+    source_repo = Repo.clone_from(str(remote_path), source_path)
+    file_path = source_path / "file.txt"
+    file_path.write_text("content")
+    source_repo.index.add(["file.txt"])
+    source_repo.index.commit("init")
+    source_repo.git.push('--all', 'origin')
+
+    local_path = tmp_path / "local"
+    local_repo = Repo.clone_from(str(remote_path), local_path)
+
+    source_repo.create_tag("v1.0.0")
+    source_repo.git.push('--tags', 'origin')
+
+    assert all(tag.name != "v1.0.0" for tag in local_repo.tags)
+    git_commands.fetch_tags(local_repo)
+    assert any(tag.name == "v1.0.0" for tag in local_repo.tags)
+
+
+def test_checkout_fetch_and_checkout_branch(tmp_path):
+    remote_dir = tmp_path / "remote"
+    remote_repo = Repo.init(remote_dir)
+    (remote_dir / "f.txt").write_text("test")
+    remote_repo.index.add(["f.txt"])
+    remote_repo.index.commit("init")
+    remote_repo.create_head("feature")
+    local_repo = Repo.clone_from(str(remote_dir), tmp_path / "local")
+    git_commands.checkout(local_repo, "pkg", "feature")
+    assert local_repo.active_branch.name == "feature"
+    assert local_repo.head.commit.hexsha == remote_repo.head.commit.hexsha
+
+
+def test_checkout_raises_for_dirty_repository(tmp_path):
+    remote_dir = tmp_path / "remote"
+    remote_repo = Repo.init(remote_dir)
+    (remote_dir / "f.txt").write_text("test")
+    remote_repo.index.add(["f.txt"])
+    remote_repo.index.commit("init")
+    remote_repo.create_head("feature")
+
+    local_repo = Repo.clone_from(str(remote_dir), tmp_path / "local")
+    (tmp_path / "local" / "f.txt").write_text("dirty")
+
+    with pytest.raises(git_commands.RepositoryDirtyError):
+        git_commands.checkout(local_repo, "pkg", "feature")
+
+
+def test_checkout_unborn_repository_to_remote_branch_tracks_matching_files(tmp_path):
+    remote_dir = tmp_path / "remote"
+    remote_repo = Repo.init(remote_dir)
+    (remote_dir / "f.txt").write_text("test")
+    remote_repo.index.add(["f.txt"])
+    remote_repo.index.commit("init")
+    remote_repo.create_head("2.x")
+
+    local_dir = tmp_path / "local"
+    local_dir.mkdir()
+    (local_dir / "f.txt").write_text("test")
+    local_repo = Repo.init(local_dir)
+    local_repo.create_remote("origin", str(remote_dir))
+
+    git_commands.checkout(local_repo, "pkg", "2.x")
+
+    assert local_repo.active_branch.name == "2.x"
+    assert not local_repo.is_dirty(untracked_files=True)
+
+
+def test_create_branch_from_remote(tmp_path):
+    remote_dir = tmp_path / "remote"
+    remote_repo = Repo.init(remote_dir)
+    (remote_dir / "f.txt").write_text("test")
+    remote_repo.index.add(["f.txt"])
+    remote_repo.index.commit("init")
+    remote_repo.create_head("2.x")
+
+    local_repo = Repo.clone_from(str(remote_dir), tmp_path / "local")
+
+    git_commands.create_branch_from_remote(local_repo, "pkg", "2.x-dev", "2.x")
+
+    assert local_repo.active_branch.name == "2.x-dev"
+    assert local_repo.head.commit.hexsha == remote_repo.refs["2.x"].commit.hexsha
+
+
+def test_create_branch_from_remote_pushes_when_requested(tmp_path):
+    remote_path = tmp_path / "remote.git"
+    remote_repo = Repo.init(remote_path, bare=True)
+    source_path = tmp_path / "source"
+    source_repo = Repo.clone_from(str(remote_path), source_path)
+    (source_path / "f.txt").write_text("test")
+    source_repo.index.add(["f.txt"])
+    source_repo.index.commit("init")
+    source_repo.create_head("2.x")
+    source_repo.git.push("--all", "origin")
+
+    local_repo = Repo.clone_from(str(remote_path), tmp_path / "local")
+
+    git_commands.create_branch_from_remote(local_repo, "pkg", "2.x-dev", "2.x", push_missing_branch=True)
+
+    remote_clone = Repo.clone_from(str(remote_path), tmp_path / "verify")
+    assert any(ref.remote_head == "2.x-dev" for ref in remote_clone.remotes.origin.refs)
+
+
+def test_create_branch_from_remote_raises_for_missing_base(tmp_path):
+    remote_dir = tmp_path / "remote"
+    remote_repo = Repo.init(remote_dir)
+    (remote_dir / "f.txt").write_text("test")
+    remote_repo.index.add(["f.txt"])
+    remote_repo.index.commit("init")
+
+    local_repo = Repo.clone_from(str(remote_dir), tmp_path / "local")
+
+    with pytest.raises(git_commands.MissingBaseBranchError):
+        git_commands.create_branch_from_remote(local_repo, "pkg", "2.x-dev", "2.x")
+
+
+def test_create_branch_from_remote_for_unborn_repo_keeps_worktree(tmp_path):
+    remote_dir = tmp_path / "remote"
+    remote_repo = Repo.init(remote_dir)
+    (remote_dir / "f.txt").write_text("test")
+    remote_repo.index.add(["f.txt"])
+    remote_repo.index.commit("init")
+    remote_repo.create_head("2.x")
+
+    local_dir = tmp_path / "local"
+    local_dir.mkdir()
+    (local_dir / "local.txt").write_text("keep me")
+    local_repo = Repo.init(local_dir)
+    local_repo.create_remote("origin", str(remote_dir))
+
+    git_commands.create_branch_from_remote(local_repo, "pkg", "2.x-dev", "2.x")
+
+    assert local_repo.active_branch.name == "2.x-dev"
+    assert (local_dir / "local.txt").read_text() == "keep me"
+
+
+def test_create_branch_from_remote_for_unborn_repo_tracks_matching_files(tmp_path):
+    remote_dir = tmp_path / "remote"
+    remote_repo = Repo.init(remote_dir)
+    (remote_dir / "f.txt").write_text("test")
+    remote_repo.index.add(["f.txt"])
+    remote_repo.index.commit("init")
+    remote_repo.create_head("2.x")
+
+    local_dir = tmp_path / "local"
+    local_dir.mkdir()
+    (local_dir / "f.txt").write_text("test")
+    local_repo = Repo.init(local_dir)
+    local_repo.create_remote("origin", str(remote_dir))
+
+    git_commands.create_branch_from_remote(local_repo, "pkg", "2.x-dev", "2.x")
+
+    assert local_repo.active_branch.name == "2.x-dev"
+    assert not local_repo.is_dirty(untracked_files=True)
+
+
+def test_create_branch_from_remote_for_unborn_repo_pushes_when_requested(tmp_path):
+    remote_dir = tmp_path / "remote"
+    remote_repo = Repo.init(remote_dir)
+    (remote_dir / "f.txt").write_text("test")
+    remote_repo.index.add(["f.txt"])
+    remote_repo.index.commit("init")
+    remote_repo.create_head("2.x")
+
+    local_dir = tmp_path / "local"
+    local_dir.mkdir()
+    (local_dir / "f.txt").write_text("test")
+    local_repo = Repo.init(local_dir)
+    local_repo.create_remote("origin", str(remote_dir))
+
+    git_commands.create_branch_from_remote(local_repo, "pkg", "2.x-dev", "2.x", push_missing_branch=True)
+
+    remote_clone = Repo.clone_from(str(remote_dir), tmp_path / "verify")
+    assert any(ref.remote_head == "2.x-dev" for ref in remote_clone.remotes.origin.refs)
+
+
+def test_commit_changes_and_get_changes(tmp_path):
+    repo_dir = tmp_path / "repo"
+    repo = Repo.init(repo_dir)
+    f1 = repo_dir / "f1.txt"
+    f1.write_text("a")
+    repo.index.add([str(f1)])
+    repo.index.commit("init")
+    f1.write_text("b")
+    f2 = repo_dir / "f2.txt"
+    f2.write_text("new")
+    f3 = repo_dir / "f3.txt"
+    f3.write_text("del")
+    repo.index.add([str(f3)])
+    repo.index.commit("tmp")
+    os.remove(f3)
+    f4 = repo_dir / "f4.txt"
+    f4.write_text("stage")
+    repo.index.add([str(f4)])
+
+
+    to_add, to_remove = git_commands.get_changes_to_commit(repo)
+    assert set(to_add) == {"f1.txt", "f2.txt"}
+    assert to_remove == ["f3.txt"]
+
+    git_commands.commit_changes(repo, "v1", "pkg")
+    assert repo.head.commit.message == "Update v1 for pkg"
+    assert not repo.is_dirty(untracked_files=True)

--- a/tests/python/test_git_commands.py
+++ b/tests/python/test_git_commands.py
@@ -66,6 +66,18 @@ def test_fetch_tags(tmp_path):
     assert any(tag.name == "v1.0.0" for tag in local_repo.tags)
 
 
+def test_has_tag(tmp_path):
+    repo = Repo.init(tmp_path)
+    file_path = tmp_path / "file.txt"
+    file_path.write_text("content")
+    repo.index.add(["file.txt"])
+    repo.index.commit("init")
+    repo.create_tag("v1.0.0")
+
+    assert git_commands.has_tag(repo, "v1.0.0") is True
+    assert git_commands.has_tag(repo, "v1.0.1") is False
+
+
 def test_checkout_fetch_and_checkout_branch(tmp_path):
     remote_dir = tmp_path / "remote"
     remote_repo = Repo.init(remote_dir)

--- a/tests/python/test_git_shell_github.py
+++ b/tests/python/test_git_shell_github.py
@@ -1,0 +1,59 @@
+import git_shell, github
+
+
+def test_create_or_update_branch_existing(monkeypatch):
+    calls = []
+    def fake_exec(cmd, cwd=None, capture_output=False):
+        calls.append((cmd, cwd, capture_output))
+        if cmd == ['git', 'branch', '-a']:
+            return 'remotes/origin/feat'
+        return ''
+    monkeypatch.setattr(git_shell, 'execute_shell_command', fake_exec)
+    git_shell.create_or_update_branch('cwd', 'feat')
+    assert calls[0][0] == ['git', 'fetch']
+    assert calls[1][0] == ['git', 'branch', '-a']
+    assert calls[2][0] == ['git', 'push', '-f']
+
+def test_create_or_update_branch_new(monkeypatch):
+    calls = []
+    def fake_exec(cmd, cwd=None, capture_output=False):
+        calls.append(cmd)
+        return "" 
+    monkeypatch.setattr(git_shell, "execute_shell_command", fake_exec)
+    git_shell.create_or_update_branch("cwd", "feat")
+    assert calls[0] == ['git', 'fetch']
+    assert calls[1] == ['git', 'branch', '-a']
+    assert calls[2] == ['git', 'checkout', '-b', 'feat']
+
+
+
+def test_commit_and_push(monkeypatch):
+    cmds = []
+    monkeypatch.setattr(git_shell, 'execute_shell_command', lambda cmd, cwd=None, capture_output=False: cmds.append(cmd) or '')
+    git_shell.commit_changes('cwd', 'msg')
+    git_shell.push_changes('cwd', 'br')
+    assert cmds == [
+        ['git', 'add', '.'],
+        ['git', 'commit', '-am', 'msg'],
+        ['git', 'push', 'origin', 'br']
+    ]
+
+
+def test_github_commands(monkeypatch):
+    cmds = []
+    monkeypatch.setattr(github, 'execute_shell_command', lambda cmd, cwd=None, capture_output=False: cmds.append(cmd) or '')
+    github.check_auth('cwd')
+    github.create_merge_request('cwd', 'main', 'feat', 'rel')
+    github.merge_pr('cwd', 'feat', 'rel')
+    github.create_release('cwd', 'main', 'rel')
+    monkeypatch.setattr(github, 'execute_shell_command', lambda cmd, cwd=None, capture_output=True: 'open')
+    assert github.check_for_open_prs('cwd', 'feat')
+    monkeypatch.setattr(github, 'execute_shell_command', lambda cmd, cwd=None, capture_output=True: 'merged')
+    assert github.check_for_merged_prs('cwd', 'feat')
+    expected = [
+        ['gh', 'auth', 'status'],
+        ['gh', 'pr', 'create', '--base', 'main', '--head', 'feat', '--title', 'Release rel', '--body', 'Automated release PR for rel'],
+        ['gh', 'pr', 'merge', 'feat', '--squash', '--delete-branch', '--subject', 'Merge Release rel'],
+        ['gh', 'release', 'create', 'rel', '--target', 'main', '--title', 'rel']
+    ]
+    assert cmds == expected

--- a/tests/python/test_packages.py
+++ b/tests/python/test_packages.py
@@ -1,0 +1,26 @@
+import json
+import packagist, packages
+
+
+def test_get_repository_link_converts_to_ssh(monkeypatch):
+    def fake_get(url):
+        class Resp:
+            def json(self):
+                return {
+                    'packages': {
+                        'pkg/name': [{
+                            'source': {'url': 'https://github.com/Org/Repo'}
+                        }]
+                    }
+                }
+        return Resp()
+    monkeypatch.setattr(packagist.requests, 'get', fake_get)
+    url = packagist.get_repository_link('pkg/name')
+    assert url == 'git@github.com:Org/Repo.git'
+
+
+def test_read_packages(tmp_path):
+    data = {'packages': {'p1': 'a', 'p2': 'b'}}
+    file = tmp_path / 'packages.json'
+    file.write_text(json.dumps(data))
+    assert packages.read_packages(file) == data['packages']

--- a/tests/python/test_scripts.py
+++ b/tests/python/test_scripts.py
@@ -181,6 +181,7 @@ def test_release_main_merge(monkeypatch, tmp_path):
     paths = {'pkg': str(tmp_path)}
     monkeypatch.setattr(release, 'read_packages', lambda f: paths)
     monkeypatch.setattr(release, 'preflight_branches', lambda packages, rel, base, merge: [])
+    monkeypatch.setattr(release, 'preflight_release_tags', lambda packages, release_name, merge: [])
     monkeypatch.setattr(release, 'preflight_clean_worktrees', lambda packages: [])
     monkeypatch.setattr(release, 'check_for_open_prs', lambda cwd, b: True)
     monkeypatch.setattr(release, 'check_for_merged_prs', lambda cwd, b: False)
@@ -206,6 +207,7 @@ def test_release_main_merge_skips_release_without_open_pr(monkeypatch, tmp_path)
     paths = {'pkg': str(tmp_path)}
     monkeypatch.setattr(release, 'read_packages', lambda f: paths)
     monkeypatch.setattr(release, 'preflight_branches', lambda packages, rel, base, merge: [])
+    monkeypatch.setattr(release, 'preflight_release_tags', lambda packages, release_name, merge: [])
     monkeypatch.setattr(release, 'preflight_clean_worktrees', lambda packages: [])
     monkeypatch.setattr(release, 'check_for_open_prs', lambda cwd, b: False)
     monkeypatch.setattr(release, 'check_for_merged_prs', lambda cwd, b: False)
@@ -228,6 +230,7 @@ def test_release_main_commit_flow(monkeypatch, tmp_path):
     repo = object()
     monkeypatch.setattr(release, 'read_packages', lambda f: paths)
     monkeypatch.setattr(release, 'preflight_branches', lambda packages, rel, base, merge: [])
+    monkeypatch.setattr(release, 'preflight_release_tags', lambda packages, release_name, merge: [])
     monkeypatch.setattr(release, 'preflight_clean_worktrees', lambda packages: [])
     monkeypatch.setattr(release, 'get_repository', lambda p: repo)
     monkeypatch.setattr(release, 'get_changes_to_commit', lambda r: (['a'], []))
@@ -248,6 +251,7 @@ def test_release_main_creates_missing_release_for_already_merged_pr(monkeypatch,
     paths = {'pkg': str(tmp_path)}
     monkeypatch.setattr(release, 'read_packages', lambda f: paths)
     monkeypatch.setattr(release, 'preflight_branches', lambda packages, rel, base, merge: [])
+    monkeypatch.setattr(release, 'preflight_release_tags', lambda packages, release_name, merge: [])
     monkeypatch.setattr(release, 'preflight_clean_worktrees', lambda packages: [])
     monkeypatch.setattr(release, 'check_for_open_prs', lambda cwd, b: False)
     monkeypatch.setattr(release, 'check_for_merged_prs', lambda cwd, b: True)
@@ -272,6 +276,7 @@ def test_release_main_skips_missing_release_recovery_when_nothing_unreleased(mon
     paths = {'pkg': str(tmp_path)}
     monkeypatch.setattr(release, 'read_packages', lambda f: paths)
     monkeypatch.setattr(release, 'preflight_branches', lambda packages, rel, base, merge: [])
+    monkeypatch.setattr(release, 'preflight_release_tags', lambda packages, release_name, merge: [])
     monkeypatch.setattr(release, 'preflight_clean_worktrees', lambda packages: [])
     monkeypatch.setattr(release, 'check_for_open_prs', lambda cwd, b: False)
     monkeypatch.setattr(release, 'check_for_merged_prs', lambda cwd, b: True)
@@ -390,6 +395,45 @@ def test_release_main_returns_preflight_failures_without_processing(monkeypatch,
     assert called == []
 
 
+def test_preflight_release_tags_fails_for_existing_tag(monkeypatch, tmp_path):
+    paths = {'pkg': str(tmp_path)}
+    repo = object()
+    monkeypatch.setattr(release, 'get_repository', lambda p: repo)
+    monkeypatch.setattr(release, 'fetch_tags', lambda repo: None)
+    monkeypatch.setattr(release, 'has_tag', lambda repo, tag_name: tag_name == 'v2.0.0-alpha1')
+
+    failed = release.preflight_release_tags(paths, 'v2.0.0-alpha1', True)
+
+    assert failed == ['pkg']
+
+
+def test_preflight_release_tags_skips_non_merge_mode(monkeypatch, tmp_path):
+    paths = {'pkg': str(tmp_path)}
+    called = []
+    monkeypatch.setattr(release, 'get_repository', lambda p: called.append('repo'))
+
+    failed = release.preflight_release_tags(paths, 'v2.0.0-alpha1', False)
+
+    assert failed == []
+    assert called == []
+
+
+def test_release_main_returns_tag_preflight_failures_without_processing(monkeypatch, tmp_path):
+    paths = {'pkg': str(tmp_path)}
+    monkeypatch.setattr(release, 'read_packages', lambda f: paths)
+    monkeypatch.setattr(release, 'check_gh_installed', lambda: True)
+    monkeypatch.setattr(release, 'validate_gh_access', lambda: True)
+    monkeypatch.setattr(release, 'preflight_branches', lambda packages, rel, base, merge: [])
+    monkeypatch.setattr(release, 'preflight_release_tags', lambda packages, release_name, merge: ['pkg'])
+    called = []
+    monkeypatch.setattr(release, 'get_repository', lambda p: called.append('repo'))
+
+    failed = release.main('v2.0.0-alpha1', 'release/1', '2.x', 'cfg', True, False, False)
+
+    assert failed == ['pkg']
+    assert called == []
+
+
 def test_preflight_clean_worktrees_fails_for_tracked_changes(tmp_path):
     repo = Repo.init(tmp_path)
     file_path = tmp_path / 'file.txt'
@@ -448,6 +492,7 @@ def test_release_main_skips_worktree_preflight_in_merge_mode(monkeypatch, tmp_pa
     paths = {'pkg': str(tmp_path)}
     monkeypatch.setattr(release, 'read_packages', lambda f: paths)
     monkeypatch.setattr(release, 'preflight_branches', lambda packages, rel, base, merge: [])
+    monkeypatch.setattr(release, 'preflight_release_tags', lambda packages, release_name, merge: [])
     called = []
     monkeypatch.setattr(release, 'preflight_clean_worktrees', lambda packages: called.append('worktree') or ['pkg'])
     monkeypatch.setattr(release, 'check_gh_installed', lambda: True)
@@ -474,10 +519,42 @@ def test_plan_package_action_reports_blocked_dirty_prepare_repo(monkeypatch, tmp
     monkeypatch.setattr(release, 'fetch_remote', lambda repo: None)
     monkeypatch.setattr(release, 'has_remote_branch', lambda repo, branch: branch == '2.x')
 
-    action, blocked = release.plan_package_action('pkg', str(tmp_path), 'release/1', '2.x', False, False, False)
+    action, blocked = release.plan_package_action(
+        'pkg',
+        str(tmp_path),
+        'v2.0.0-alpha1',
+        'release/1',
+        '2.x',
+        False,
+        False,
+        False
+    )
 
     assert blocked is True
     assert 'local changes or untracked files' in action
+
+
+def test_plan_package_action_reports_existing_release_tag(monkeypatch, tmp_path):
+    repo = object()
+    monkeypatch.setattr(release, 'get_repository', lambda p: repo)
+    monkeypatch.setattr(release, 'fetch_remote', lambda repo: None)
+    monkeypatch.setattr(release, 'fetch_tags', lambda repo: None)
+    monkeypatch.setattr(release, 'has_remote_branch', lambda repo, branch: True)
+    monkeypatch.setattr(release, 'has_tag', lambda repo, tag_name: tag_name == 'v2.0.0-alpha1')
+
+    action, blocked = release.plan_package_action(
+        'pkg',
+        str(tmp_path),
+        'v2.0.0-alpha1',
+        'release/1',
+        '2.x',
+        True,
+        False,
+        False
+    )
+
+    assert blocked is True
+    assert 'release tag `v2.0.0-alpha1` already exists' in action
 
 
 def test_release_main_dry_run_uses_preview_without_running_preflight(monkeypatch, tmp_path):

--- a/tests/python/test_scripts.py
+++ b/tests/python/test_scripts.py
@@ -1,0 +1,531 @@
+import os
+import logging
+import argparse
+import subprocess
+import sys
+from types import SimpleNamespace
+import pytest
+from git import Repo
+import init, fix, release, clean
+from git_commands import MissingBranchError, RepositoryDirtyError, MissingBaseBranchError
+
+
+def test_init_handles_missing_branch(monkeypatch, capsys, tmp_path):
+    monkeypatch.setattr(init, 'read_packages', lambda f: {'pkg': str(tmp_path)})
+    monkeypatch.setattr(init, 'get_repository_link', lambda pkg: 'url')
+    monkeypatch.setattr(init, 'init_repository', lambda folder, repo, branch: 'repo')
+    def fake_checkout(repo, package, branch):
+        raise MissingBranchError('missing')
+    monkeypatch.setattr(init, 'checkout', fake_checkout)
+    init.main('2.x', 'cfg')
+    captured = capsys.readouterr()
+    assert 'pkg' in captured.out
+
+
+def test_init_creates_missing_branch_from_fallback(monkeypatch, tmp_path):
+    monkeypatch.setattr(init, 'read_packages', lambda f: {'pkg': str(tmp_path)})
+    monkeypatch.setattr(init, 'get_repository_link', lambda pkg: 'url')
+    monkeypatch.setattr(init, 'init_repository', lambda folder, repo, branch: 'repo')
+
+    calls = []
+
+    def fake_checkout(repo, package, branch):
+        calls.append(branch)
+        raise MissingBranchError('missing')
+
+    called = {}
+
+    def fake_create(repo, package, branch, from_branch, push_missing_branches):
+        called['args'] = (package, branch, from_branch, push_missing_branches)
+
+    monkeypatch.setattr(init, 'checkout', fake_checkout)
+    monkeypatch.setattr(init, 'create_branch_from_remote', fake_create)
+
+    init.main('2.x-dev', 'cfg', from_branch='2.x', push_missing_branches=True)
+
+    assert calls == ['2.x-dev']
+    assert called['args'] == ('pkg', '2.x-dev', '2.x', True)
+
+
+def test_init_checks_out_fallback_branch_when_push_not_requested(monkeypatch, tmp_path):
+    monkeypatch.setattr(init, 'read_packages', lambda f: {'pkg': str(tmp_path)})
+    monkeypatch.setattr(init, 'get_repository_link', lambda pkg: 'url')
+    monkeypatch.setattr(init, 'init_repository', lambda folder, repo, branch: 'repo')
+
+    calls = []
+
+    def fake_checkout(repo, package, branch):
+        calls.append(branch)
+        if branch == '2.x-dev':
+            raise MissingBranchError('missing')
+
+    monkeypatch.setattr(init, 'checkout', fake_checkout)
+
+    init.main('2.x-dev', 'cfg', from_branch='2.x', push_missing_branches=False)
+
+    assert calls == ['2.x-dev', '2.x']
+
+
+def test_init_reports_missing_fallback_branch(monkeypatch, capsys, tmp_path):
+    monkeypatch.setattr(init, 'read_packages', lambda f: {'pkg': str(tmp_path)})
+    monkeypatch.setattr(init, 'get_repository_link', lambda pkg: 'url')
+    monkeypatch.setattr(init, 'init_repository', lambda folder, repo, branch: 'repo')
+
+    def fake_checkout(repo, package, branch):
+        raise MissingBranchError('missing')
+
+    def fake_create(repo, package, branch, from_branch, push_missing_branches):
+        raise MissingBaseBranchError('missing base')
+
+    monkeypatch.setattr(init, 'checkout', fake_checkout)
+    monkeypatch.setattr(init, 'create_branch_from_remote', fake_create)
+
+    init.main('2.x-dev', 'cfg', from_branch='2.x')
+
+    captured = capsys.readouterr()
+    assert 'fallback 2.x branch' in captured.out
+
+
+def test_init_reports_dirty_repository(monkeypatch, capsys, tmp_path):
+    monkeypatch.setattr(init, 'read_packages', lambda f: {'pkg': str(tmp_path)})
+    monkeypatch.setattr(init, 'get_repository_link', lambda pkg: 'url')
+    monkeypatch.setattr(init, 'init_repository', lambda folder, repo, branch: 'repo')
+
+    def fake_checkout(repo, package, branch):
+        raise RepositoryDirtyError('dirty')
+
+    monkeypatch.setattr(init, 'checkout', fake_checkout)
+    init.main('2.x', 'cfg')
+    captured = capsys.readouterr()
+    assert 'local changes' in captured.out
+
+
+def test_fix_main_logs_errors(monkeypatch, caplog, tmp_path):
+    paths = {'pkg1': str(tmp_path / 'p1'), 'pkg2': str(tmp_path / 'p2')}
+    for p in paths.values():
+        os.makedirs(p)
+    monkeypatch.setattr(fix, 'read_packages', lambda f: paths)
+    monkeypatch.setattr(fix, 'get_repository_link', lambda pkg: 'url')
+    def fake_get_repo(path):
+        if path.endswith('p1'):
+            raise fix.InvalidGitRepositoryError('bad')
+        return 'repo'
+    monkeypatch.setattr(fix, 'get_repository', fake_get_repo)
+    def fake_update(repo, name, url):
+        if repo == 'repo' and name == 'origin':
+            raise Exception('err')
+    monkeypatch.setattr(fix, 'update_repository_remote_link', fake_update)
+    caplog.set_level(logging.ERROR)
+    fix.main('cfg')
+    assert 'pkg1' in caplog.text
+    assert 'pkg2' in caplog.text
+
+
+def test_clean_removes_git_directory(tmp_path):
+    package_dir = tmp_path / 'pkg'
+    git_dir = package_dir / '.git'
+    git_dir.mkdir(parents=True)
+    (package_dir / 'file.txt').write_text('keep me')
+
+    removed = clean.remove_git_metadata(str(package_dir))
+
+    assert removed is True
+    assert not git_dir.exists()
+    assert (package_dir / 'file.txt').read_text() == 'keep me'
+
+
+def test_clean_removes_git_file(tmp_path):
+    package_dir = tmp_path / 'pkg'
+    package_dir.mkdir(parents=True)
+    git_file = package_dir / '.git'
+    git_file.write_text('gitdir: /tmp/example')
+
+    removed = clean.remove_git_metadata(str(package_dir))
+
+    assert removed is True
+    assert not git_file.exists()
+
+
+def test_clean_main_processes_packages(monkeypatch, tmp_path):
+    paths = {'pkg1': str(tmp_path / 'p1'), 'pkg2': str(tmp_path / 'p2')}
+    monkeypatch.setattr(clean, 'read_packages', lambda f: paths)
+    removed = []
+    monkeypatch.setattr(clean, 'remove_git_metadata', lambda path: removed.append(path) or path.endswith('p1'))
+
+    cleaned = clean.main('cfg')
+
+    assert removed == [str(tmp_path / 'p1'), str(tmp_path / 'p2')]
+    assert cleaned == [str(tmp_path / 'p1')]
+
+
+def test_all_scripts_support_help():
+    scripts_dir = os.path.join(os.path.dirname(__file__), '..', '..', 'scripts')
+
+    for script_name in sorted(name for name in os.listdir(scripts_dir) if name.endswith('.py')):
+        result = subprocess.run(
+            [sys.executable, script_name, '--help'],
+            cwd=scripts_dir,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False
+        )
+        combined_output = f'{result.stdout}\n{result.stderr}'
+
+        assert result.returncode == 0, f'--help failed for {script_name}: {combined_output}'
+        assert 'usage:' in combined_output.lower(), f'No usage output for {script_name}'
+
+
+def test_release_main_merge(monkeypatch, tmp_path):
+    paths = {'pkg': str(tmp_path)}
+    monkeypatch.setattr(release, 'read_packages', lambda f: paths)
+    monkeypatch.setattr(release, 'preflight_branches', lambda packages, rel, base, merge: [])
+    monkeypatch.setattr(release, 'preflight_clean_worktrees', lambda packages: [])
+    monkeypatch.setattr(release, 'check_for_open_prs', lambda cwd, b: True)
+    monkeypatch.setattr(release, 'check_for_merged_prs', lambda cwd, b: False)
+    monkeypatch.setattr(release, 'check_gh_installed', lambda: True)
+    monkeypatch.setattr(release, 'validate_gh_access', lambda: True)
+    monkeypatch.setattr(release, 'get_repository', lambda p: object())
+    monkeypatch.setattr(release, 'compute_next_version', lambda r: 'v2.0.1')
+    monkeypatch.setattr(release, 'collect_release_notes', lambda r, b: 'notes')
+    called = {}
+    monkeypatch.setattr(release, 'fetch_tags', lambda repo: called.setdefault('fetch_tags', True))
+    def fake_merge(cwd, b, r):
+        called['merge'] = r
+    def fake_release(cwd, base, r, notes):
+        called['release'] = (r, notes)
+    monkeypatch.setattr(release, 'merge_pr', fake_merge)
+    monkeypatch.setattr(release, 'create_release', fake_release)
+    failed = release.main('v1', 'br', 'base', 'cfg', True, False, False)
+    assert failed == []
+    assert called == {'fetch_tags': True, 'merge': 'v2.0.1', 'release': ('v2.0.1', 'notes')}
+
+
+def test_release_main_merge_skips_release_without_open_pr(monkeypatch, tmp_path):
+    paths = {'pkg': str(tmp_path)}
+    monkeypatch.setattr(release, 'read_packages', lambda f: paths)
+    monkeypatch.setattr(release, 'preflight_branches', lambda packages, rel, base, merge: [])
+    monkeypatch.setattr(release, 'preflight_clean_worktrees', lambda packages: [])
+    monkeypatch.setattr(release, 'check_for_open_prs', lambda cwd, b: False)
+    monkeypatch.setattr(release, 'check_for_merged_prs', lambda cwd, b: False)
+    monkeypatch.setattr(release, 'check_gh_installed', lambda: True)
+    monkeypatch.setattr(release, 'validate_gh_access', lambda: True)
+    monkeypatch.setattr(release, 'get_repository', lambda p: object())
+    monkeypatch.setattr(release, 'fetch_tags', lambda repo: None)
+    actions = []
+    monkeypatch.setattr(release, 'merge_pr', lambda *args: actions.append('merge'))
+    monkeypatch.setattr(release, 'create_release', lambda *args: actions.append('release'))
+
+    failed = release.main('v1', 'br', 'base', 'cfg', True, False, False)
+
+    assert failed == []
+    assert actions == []
+
+
+def test_release_main_commit_flow(monkeypatch, tmp_path):
+    paths = {'pkg': str(tmp_path)}
+    repo = object()
+    monkeypatch.setattr(release, 'read_packages', lambda f: paths)
+    monkeypatch.setattr(release, 'preflight_branches', lambda packages, rel, base, merge: [])
+    monkeypatch.setattr(release, 'preflight_clean_worktrees', lambda packages: [])
+    monkeypatch.setattr(release, 'get_repository', lambda p: repo)
+    monkeypatch.setattr(release, 'get_changes_to_commit', lambda r: (['a'], []))
+    monkeypatch.setattr(release, 'check_gh_installed', lambda: True)
+    monkeypatch.setattr(release, 'validate_gh_access', lambda: True)
+    actions = []
+    monkeypatch.setattr(release, 'create_or_update_branch', lambda r, pkg, br: actions.append('branch'))
+    monkeypatch.setattr(release, 'commit_changes', lambda r, rn, pkg: actions.append('commit'))
+    monkeypatch.setattr(release, 'push_changes', lambda r: actions.append('push'))
+    monkeypatch.setattr(release, 'check_for_open_prs', lambda c, b: False)
+    monkeypatch.setattr(release, 'create_merge_request', lambda c, base, br, rn: actions.append('pr'))
+    failed = release.main('v1', 'br', 'base', 'cfg', False, False, False)
+    assert failed == []
+    assert actions == ['branch', 'commit', 'push', 'pr']
+
+
+def test_release_main_creates_missing_release_for_already_merged_pr(monkeypatch, tmp_path):
+    paths = {'pkg': str(tmp_path)}
+    monkeypatch.setattr(release, 'read_packages', lambda f: paths)
+    monkeypatch.setattr(release, 'preflight_branches', lambda packages, rel, base, merge: [])
+    monkeypatch.setattr(release, 'preflight_clean_worktrees', lambda packages: [])
+    monkeypatch.setattr(release, 'check_for_open_prs', lambda cwd, b: False)
+    monkeypatch.setattr(release, 'check_for_merged_prs', lambda cwd, b: True)
+    monkeypatch.setattr(release, 'check_gh_installed', lambda: True)
+    monkeypatch.setattr(release, 'validate_gh_access', lambda: True)
+    monkeypatch.setattr(release, 'get_repository', lambda p: object())
+    monkeypatch.setattr(release, 'fetch_tags', lambda repo: None)
+    monkeypatch.setattr(release, 'has_unreleased_commits', lambda repo, branch: True)
+    monkeypatch.setattr(release, 'compute_next_version', lambda r: 'v2.0.1')
+    monkeypatch.setattr(release, 'collect_release_notes', lambda r, b: 'notes')
+    actions = []
+    monkeypatch.setattr(release, 'merge_pr', lambda *args: actions.append('merge'))
+    monkeypatch.setattr(release, 'create_release', lambda cwd, base, rel, notes: actions.append((base, rel, notes)))
+
+    failed = release.main('v1', 'br', 'base', 'cfg', True, False, False)
+
+    assert failed == []
+    assert actions == [('base', 'v2.0.1', 'notes')]
+
+
+def test_release_main_skips_missing_release_recovery_when_nothing_unreleased(monkeypatch, tmp_path):
+    paths = {'pkg': str(tmp_path)}
+    monkeypatch.setattr(release, 'read_packages', lambda f: paths)
+    monkeypatch.setattr(release, 'preflight_branches', lambda packages, rel, base, merge: [])
+    monkeypatch.setattr(release, 'preflight_clean_worktrees', lambda packages: [])
+    monkeypatch.setattr(release, 'check_for_open_prs', lambda cwd, b: False)
+    monkeypatch.setattr(release, 'check_for_merged_prs', lambda cwd, b: True)
+    monkeypatch.setattr(release, 'check_gh_installed', lambda: True)
+    monkeypatch.setattr(release, 'validate_gh_access', lambda: True)
+    monkeypatch.setattr(release, 'get_repository', lambda p: object())
+    monkeypatch.setattr(release, 'fetch_tags', lambda repo: None)
+    monkeypatch.setattr(release, 'has_unreleased_commits', lambda repo, branch: False)
+    actions = []
+    monkeypatch.setattr(release, 'merge_pr', lambda *args: actions.append('merge'))
+    monkeypatch.setattr(release, 'create_release', lambda *args: actions.append('release'))
+
+    failed = release.main('v1', 'br', 'base', 'cfg', True, False, False)
+
+    assert failed == []
+    assert actions == []
+
+
+def test_release_cli_requires_base_branch(monkeypatch):
+    monkeypatch.setattr(release, 'check_gh_installed', lambda: True)
+    captured = {}
+
+    def fake_error(self, message):
+        captured['msg'] = message
+        raise SystemExit(2)
+
+    monkeypatch.setattr(argparse.ArgumentParser, 'error', fake_error, raising=False)
+    with pytest.raises(SystemExit):
+        release.run_cli(['--release-branch', 'rel-branch', '--config', 'cfg', 'rel'])
+    assert 'base-branch' in captured['msg']
+
+
+def test_release_cli_requires_release_branch(monkeypatch):
+    monkeypatch.setattr(release, 'check_gh_installed', lambda: True)
+    captured = {}
+
+    def fake_error(self, message):
+        captured['msg'] = message
+        raise SystemExit(2)
+
+    monkeypatch.setattr(argparse.ArgumentParser, 'error', fake_error, raising=False)
+    with pytest.raises(SystemExit):
+        release.run_cli(['--base-branch', '2.x', '--config', 'cfg', 'rel'])
+    assert 'release-branch' in captured['msg']
+
+
+def test_release_cli_exits_non_zero_on_failed_packages(monkeypatch):
+    monkeypatch.setattr(release, 'main', lambda *args: ['pkg'])
+    monkeypatch.setattr(release, 'os', os)
+
+    with pytest.raises(SystemExit) as exc:
+        release.run_cli(['--base-branch', '2.x', '--release-branch', 'release/1', '--config', 'cfg', 'rel'])
+
+    assert exc.value.code == 1
+
+
+def test_validate_gh_access_handles_shell_error(monkeypatch, caplog):
+    monkeypatch.setattr(release, 'check_auth', lambda: (_ for _ in ()).throw(release.ShellError('bad auth')))
+    caplog.set_level(logging.ERROR)
+
+    assert release.validate_gh_access() is False
+    assert 'authentication check failed' in caplog.text
+
+
+def test_preflight_branches_fails_for_missing_base_branch(monkeypatch, tmp_path):
+    paths = {'pkg': str(tmp_path)}
+    repo = object()
+    monkeypatch.setattr(release, 'get_repository', lambda p: repo)
+    monkeypatch.setattr(release, 'fetch_remote', lambda repo: None)
+    monkeypatch.setattr(release, 'has_remote_branch', lambda repo, branch: branch == 'release/1')
+    monkeypatch.setattr(release, 'check_for_merged_prs', lambda cwd, branch: False)
+
+    failed = release.preflight_branches(paths, 'release/1', '2.x', False)
+
+    assert failed == ['pkg']
+
+
+def test_preflight_branches_fails_for_missing_release_branch_in_prepare(monkeypatch, tmp_path):
+    paths = {'pkg': str(tmp_path)}
+    repo = object()
+    monkeypatch.setattr(release, 'get_repository', lambda p: repo)
+    monkeypatch.setattr(release, 'fetch_remote', lambda repo: None)
+    monkeypatch.setattr(release, 'has_remote_branch', lambda repo, branch: branch == '2.x')
+    monkeypatch.setattr(release, 'check_for_merged_prs', lambda cwd, branch: False)
+
+    failed = release.preflight_branches(paths, 'release/1', '2.x', False)
+
+    assert failed == ['pkg']
+
+
+def test_preflight_branches_allows_missing_release_branch_for_merged_pr_recovery(monkeypatch, tmp_path):
+    paths = {'pkg': str(tmp_path)}
+    repo = object()
+    monkeypatch.setattr(release, 'get_repository', lambda p: repo)
+    monkeypatch.setattr(release, 'fetch_remote', lambda repo: None)
+    monkeypatch.setattr(release, 'has_remote_branch', lambda repo, branch: branch == '2.x')
+    monkeypatch.setattr(release, 'check_for_merged_prs', lambda cwd, branch: True)
+
+    failed = release.preflight_branches(paths, 'release/1', '2.x', True)
+
+    assert failed == []
+
+
+def test_release_main_returns_preflight_failures_without_processing(monkeypatch, tmp_path):
+    paths = {'pkg': str(tmp_path)}
+    monkeypatch.setattr(release, 'read_packages', lambda f: paths)
+    monkeypatch.setattr(release, 'check_gh_installed', lambda: True)
+    monkeypatch.setattr(release, 'validate_gh_access', lambda: True)
+    monkeypatch.setattr(release, 'preflight_branches', lambda packages, rel, base, merge: ['pkg'])
+    called = []
+    monkeypatch.setattr(release, 'get_repository', lambda p: called.append('repo'))
+
+    failed = release.main('v1', 'release/1', '2.x', 'cfg', False, False, False)
+
+    assert failed == ['pkg']
+    assert called == []
+
+
+def test_preflight_clean_worktrees_fails_for_tracked_changes(tmp_path):
+    repo = Repo.init(tmp_path)
+    file_path = tmp_path / 'file.txt'
+    file_path.write_text('a')
+    repo.index.add(['file.txt'])
+    repo.index.commit('init')
+    file_path.write_text('b')
+
+    failed = release.preflight_clean_worktrees({'pkg': str(tmp_path)})
+
+    assert failed == ['pkg']
+
+
+def test_preflight_clean_worktrees_fails_for_untracked_files(tmp_path):
+    repo = Repo.init(tmp_path)
+    file_path = tmp_path / 'file.txt'
+    file_path.write_text('a')
+    repo.index.add(['file.txt'])
+    repo.index.commit('init')
+    (tmp_path / 'extra.txt').write_text('untracked')
+
+    failed = release.preflight_clean_worktrees({'pkg': str(tmp_path)})
+
+    assert failed == ['pkg']
+
+
+def test_preflight_clean_worktrees_passes_for_clean_repo(tmp_path):
+    repo = Repo.init(tmp_path)
+    file_path = tmp_path / 'file.txt'
+    file_path.write_text('a')
+    repo.index.add(['file.txt'])
+    repo.index.commit('init')
+
+    failed = release.preflight_clean_worktrees({'pkg': str(tmp_path)})
+
+    assert failed == []
+
+
+def test_release_main_returns_worktree_preflight_failures_without_processing(monkeypatch, tmp_path):
+    paths = {'pkg': str(tmp_path)}
+    monkeypatch.setattr(release, 'read_packages', lambda f: paths)
+    monkeypatch.setattr(release, 'check_gh_installed', lambda: True)
+    monkeypatch.setattr(release, 'validate_gh_access', lambda: True)
+    monkeypatch.setattr(release, 'preflight_branches', lambda packages, rel, base, merge: [])
+    monkeypatch.setattr(release, 'preflight_clean_worktrees', lambda packages: ['pkg'])
+    called = []
+    monkeypatch.setattr(release, 'get_repository', lambda p: called.append('repo'))
+
+    failed = release.main('v1', 'release/1', '2.x', 'cfg', False, False, False)
+
+    assert failed == ['pkg']
+    assert called == []
+
+
+def test_release_main_skips_worktree_preflight_in_merge_mode(monkeypatch, tmp_path):
+    paths = {'pkg': str(tmp_path)}
+    monkeypatch.setattr(release, 'read_packages', lambda f: paths)
+    monkeypatch.setattr(release, 'preflight_branches', lambda packages, rel, base, merge: [])
+    called = []
+    monkeypatch.setattr(release, 'preflight_clean_worktrees', lambda packages: called.append('worktree') or ['pkg'])
+    monkeypatch.setattr(release, 'check_gh_installed', lambda: True)
+    monkeypatch.setattr(release, 'validate_gh_access', lambda: True)
+    monkeypatch.setattr(release, 'get_repository', lambda p: object())
+    monkeypatch.setattr(release, 'fetch_tags', lambda repo: None)
+    monkeypatch.setattr(release, 'check_for_open_prs', lambda cwd, b: False)
+    monkeypatch.setattr(release, 'check_for_merged_prs', lambda cwd, b: False)
+
+    failed = release.main('v1', 'release/1', '2.x', 'cfg', True, False, False)
+
+    assert failed == []
+    assert called == []
+
+
+def test_plan_package_action_reports_blocked_dirty_prepare_repo(monkeypatch, tmp_path):
+    repo = Repo.init(tmp_path)
+    file_path = tmp_path / 'file.txt'
+    file_path.write_text('a')
+    repo.index.add(['file.txt'])
+    repo.index.commit('init')
+    file_path.write_text('dirty')
+
+    monkeypatch.setattr(release, 'fetch_remote', lambda repo: None)
+    monkeypatch.setattr(release, 'has_remote_branch', lambda repo, branch: branch == '2.x')
+
+    action, blocked = release.plan_package_action('pkg', str(tmp_path), 'release/1', '2.x', False, False, False)
+
+    assert blocked is True
+    assert 'local changes or untracked files' in action
+
+
+def test_release_main_dry_run_uses_preview_without_running_preflight(monkeypatch, tmp_path):
+    paths = {'pkg': str(tmp_path)}
+    monkeypatch.setattr(release, 'read_packages', lambda f: paths)
+    monkeypatch.setattr(release, 'check_gh_installed', lambda: True)
+    monkeypatch.setattr(release, 'validate_gh_access', lambda: True)
+    monkeypatch.setattr(release, 'preview_actions', lambda *args: [])
+    called = []
+    monkeypatch.setattr(release, 'preflight_branches', lambda *args: called.append('branches') or [])
+    monkeypatch.setattr(release, 'preflight_clean_worktrees', lambda *args: called.append('worktrees') or [])
+
+    failed = release.main('v1', 'release/1', '2.x', 'cfg', False, False, False, dry_run=True)
+
+    assert failed == []
+    assert called == []
+
+
+def test_release_main_status_returns_blocked_preview_packages(monkeypatch, tmp_path):
+    paths = {'pkg': str(tmp_path)}
+    monkeypatch.setattr(release, 'read_packages', lambda f: paths)
+    monkeypatch.setattr(release, 'check_gh_installed', lambda: True)
+    monkeypatch.setattr(release, 'validate_gh_access', lambda: True)
+    monkeypatch.setattr(release, 'preview_actions', lambda *args: ['pkg'])
+
+    failed = release.main('v1', 'release/1', '2.x', 'cfg', False, False, False, status=True)
+
+    assert failed == ['pkg']
+
+
+def test_collect_release_notes_uses_commit_subjects_for_squash_flow(tmp_path):
+    repo = Repo.init(tmp_path)
+    file_path = tmp_path / 'file.txt'
+
+    file_path.write_text('base')
+    repo.index.add(['file.txt'])
+    repo.index.commit('Initial commit')
+    repo.create_head('main')
+    repo.heads['main'].checkout()
+    repo.create_tag('v1.0.0')
+
+    file_path.write_text('change 1')
+    repo.index.add(['file.txt'])
+    repo.index.commit('Release feature A\n\nbody text')
+
+    file_path.write_text('change 2')
+    repo.index.add(['file.txt'])
+    repo.index.commit('Fix bug B')
+
+    notes = release.collect_release_notes(repo, 'main')
+
+    assert notes == 'Release feature A\nFix bug B'

--- a/tests/python/test_scripts.py
+++ b/tests/python/test_scripts.py
@@ -160,8 +160,9 @@ def test_clean_main_processes_packages(monkeypatch, tmp_path):
 
 def test_all_scripts_support_help():
     scripts_dir = os.path.join(os.path.dirname(__file__), '..', '..', 'scripts')
+    runnable_scripts = ['clean.py', 'fix.py', 'init.py', 'release.py']
 
-    for script_name in sorted(name for name in os.listdir(scripts_dir) if name.endswith('.py')):
+    for script_name in runnable_scripts:
         result = subprocess.run(
             [sys.executable, script_name, '--help'],
             cwd=scripts_dir,

--- a/tests/python/test_scripts.py
+++ b/tests/python/test_scripts.py
@@ -180,8 +180,8 @@ def test_all_scripts_support_help():
 def test_release_main_merge(monkeypatch, tmp_path):
     paths = {'pkg': str(tmp_path)}
     monkeypatch.setattr(release, 'read_packages', lambda f: paths)
-    monkeypatch.setattr(release, 'preflight_branches', lambda packages, rel, base, merge: [])
-    monkeypatch.setattr(release, 'preflight_release_tags', lambda packages, release_name, merge: [])
+    monkeypatch.setattr(release, 'preflight_branches', lambda packages, rel, base, merge, release_current: [])
+    monkeypatch.setattr(release, 'preflight_release_tags', lambda packages, release_name, merge, release_current: [])
     monkeypatch.setattr(release, 'preflight_clean_worktrees', lambda packages: [])
     monkeypatch.setattr(release, 'check_for_open_prs', lambda cwd, b: True)
     monkeypatch.setattr(release, 'check_for_merged_prs', lambda cwd, b: False)
@@ -198,7 +198,7 @@ def test_release_main_merge(monkeypatch, tmp_path):
         called['release'] = (r, notes)
     monkeypatch.setattr(release, 'merge_pr', fake_merge)
     monkeypatch.setattr(release, 'create_release', fake_release)
-    failed = release.main('v1', 'br', 'base', 'cfg', True, False, False)
+    failed = release.main('v1', 'br', 'base', 'cfg', True, False, False, False, False)
     assert failed == []
     assert called == {'fetch_tags': True, 'merge': 'v2.0.1', 'release': ('v2.0.1', 'notes')}
 
@@ -206,8 +206,8 @@ def test_release_main_merge(monkeypatch, tmp_path):
 def test_release_main_merge_skips_release_without_open_pr(monkeypatch, tmp_path):
     paths = {'pkg': str(tmp_path)}
     monkeypatch.setattr(release, 'read_packages', lambda f: paths)
-    monkeypatch.setattr(release, 'preflight_branches', lambda packages, rel, base, merge: [])
-    monkeypatch.setattr(release, 'preflight_release_tags', lambda packages, release_name, merge: [])
+    monkeypatch.setattr(release, 'preflight_branches', lambda packages, rel, base, merge, release_current: [])
+    monkeypatch.setattr(release, 'preflight_release_tags', lambda packages, release_name, merge, release_current: [])
     monkeypatch.setattr(release, 'preflight_clean_worktrees', lambda packages: [])
     monkeypatch.setattr(release, 'check_for_open_prs', lambda cwd, b: False)
     monkeypatch.setattr(release, 'check_for_merged_prs', lambda cwd, b: False)
@@ -219,7 +219,7 @@ def test_release_main_merge_skips_release_without_open_pr(monkeypatch, tmp_path)
     monkeypatch.setattr(release, 'merge_pr', lambda *args: actions.append('merge'))
     monkeypatch.setattr(release, 'create_release', lambda *args: actions.append('release'))
 
-    failed = release.main('v1', 'br', 'base', 'cfg', True, False, False)
+    failed = release.main('v1', 'br', 'base', 'cfg', True, False, False, False, False)
 
     assert failed == []
     assert actions == []
@@ -229,8 +229,8 @@ def test_release_main_commit_flow(monkeypatch, tmp_path):
     paths = {'pkg': str(tmp_path)}
     repo = object()
     monkeypatch.setattr(release, 'read_packages', lambda f: paths)
-    monkeypatch.setattr(release, 'preflight_branches', lambda packages, rel, base, merge: [])
-    monkeypatch.setattr(release, 'preflight_release_tags', lambda packages, release_name, merge: [])
+    monkeypatch.setattr(release, 'preflight_branches', lambda packages, rel, base, merge, release_current: [])
+    monkeypatch.setattr(release, 'preflight_release_tags', lambda packages, release_name, merge, release_current: [])
     monkeypatch.setattr(release, 'preflight_clean_worktrees', lambda packages: [])
     monkeypatch.setattr(release, 'get_repository', lambda p: repo)
     monkeypatch.setattr(release, 'get_changes_to_commit', lambda r: (['a'], []))
@@ -242,7 +242,7 @@ def test_release_main_commit_flow(monkeypatch, tmp_path):
     monkeypatch.setattr(release, 'push_changes', lambda r: actions.append('push'))
     monkeypatch.setattr(release, 'check_for_open_prs', lambda c, b: False)
     monkeypatch.setattr(release, 'create_merge_request', lambda c, base, br, rn: actions.append('pr'))
-    failed = release.main('v1', 'br', 'base', 'cfg', False, False, False)
+    failed = release.main('v1', 'br', 'base', 'cfg', False, False, False, False, False)
     assert failed == []
     assert actions == ['branch', 'commit', 'push', 'pr']
 
@@ -250,8 +250,8 @@ def test_release_main_commit_flow(monkeypatch, tmp_path):
 def test_release_main_creates_missing_release_for_already_merged_pr(monkeypatch, tmp_path):
     paths = {'pkg': str(tmp_path)}
     monkeypatch.setattr(release, 'read_packages', lambda f: paths)
-    monkeypatch.setattr(release, 'preflight_branches', lambda packages, rel, base, merge: [])
-    monkeypatch.setattr(release, 'preflight_release_tags', lambda packages, release_name, merge: [])
+    monkeypatch.setattr(release, 'preflight_branches', lambda packages, rel, base, merge, release_current: [])
+    monkeypatch.setattr(release, 'preflight_release_tags', lambda packages, release_name, merge, release_current: [])
     monkeypatch.setattr(release, 'preflight_clean_worktrees', lambda packages: [])
     monkeypatch.setattr(release, 'check_for_open_prs', lambda cwd, b: False)
     monkeypatch.setattr(release, 'check_for_merged_prs', lambda cwd, b: True)
@@ -266,7 +266,7 @@ def test_release_main_creates_missing_release_for_already_merged_pr(monkeypatch,
     monkeypatch.setattr(release, 'merge_pr', lambda *args: actions.append('merge'))
     monkeypatch.setattr(release, 'create_release', lambda cwd, base, rel, notes: actions.append((base, rel, notes)))
 
-    failed = release.main('v1', 'br', 'base', 'cfg', True, False, False)
+    failed = release.main('v1', 'br', 'base', 'cfg', True, False, False, False, False)
 
     assert failed == []
     assert actions == [('base', 'v2.0.1', 'notes')]
@@ -275,8 +275,8 @@ def test_release_main_creates_missing_release_for_already_merged_pr(monkeypatch,
 def test_release_main_skips_missing_release_recovery_when_nothing_unreleased(monkeypatch, tmp_path):
     paths = {'pkg': str(tmp_path)}
     monkeypatch.setattr(release, 'read_packages', lambda f: paths)
-    monkeypatch.setattr(release, 'preflight_branches', lambda packages, rel, base, merge: [])
-    monkeypatch.setattr(release, 'preflight_release_tags', lambda packages, release_name, merge: [])
+    monkeypatch.setattr(release, 'preflight_branches', lambda packages, rel, base, merge, release_current: [])
+    monkeypatch.setattr(release, 'preflight_release_tags', lambda packages, release_name, merge, release_current: [])
     monkeypatch.setattr(release, 'preflight_clean_worktrees', lambda packages: [])
     monkeypatch.setattr(release, 'check_for_open_prs', lambda cwd, b: False)
     monkeypatch.setattr(release, 'check_for_merged_prs', lambda cwd, b: True)
@@ -289,7 +289,49 @@ def test_release_main_skips_missing_release_recovery_when_nothing_unreleased(mon
     monkeypatch.setattr(release, 'merge_pr', lambda *args: actions.append('merge'))
     monkeypatch.setattr(release, 'create_release', lambda *args: actions.append('release'))
 
-    failed = release.main('v1', 'br', 'base', 'cfg', True, False, False)
+    failed = release.main('v1', 'br', 'base', 'cfg', True, False, False, False, False)
+
+    assert failed == []
+    assert actions == []
+
+
+def test_release_main_release_current_creates_release_from_base_branch(monkeypatch, tmp_path):
+    paths = {'pkg': str(tmp_path)}
+    monkeypatch.setattr(release, 'read_packages', lambda f: paths)
+    monkeypatch.setattr(release, 'preflight_branches', lambda packages, rel, base, merge, release_current: [])
+    monkeypatch.setattr(release, 'preflight_release_tags', lambda packages, release_name, merge, release_current: [])
+    monkeypatch.setattr(release, 'preflight_clean_worktrees', lambda packages: [])
+    monkeypatch.setattr(release, 'check_gh_installed', lambda: True)
+    monkeypatch.setattr(release, 'validate_gh_access', lambda: True)
+    monkeypatch.setattr(release, 'get_repository', lambda p: object())
+    monkeypatch.setattr(release, 'fetch_tags', lambda repo: None)
+    monkeypatch.setattr(release, 'has_unreleased_commits', lambda repo, branch: True)
+    monkeypatch.setattr(release, 'checkout', lambda repo, package, branch: None)
+    monkeypatch.setattr(release, 'collect_release_notes', lambda r, b: 'notes')
+    actions = []
+    monkeypatch.setattr(release, 'create_release', lambda cwd, base, rel, notes: actions.append((base, rel, notes)))
+
+    failed = release.main('v2.0.0-alpha1', None, '2.x', 'cfg', False, True, False, False, False)
+
+    assert failed == []
+    assert actions == [('2.x', 'v2.0.0-alpha1', 'notes')]
+
+
+def test_release_main_release_current_skips_when_nothing_unreleased(monkeypatch, tmp_path):
+    paths = {'pkg': str(tmp_path)}
+    monkeypatch.setattr(release, 'read_packages', lambda f: paths)
+    monkeypatch.setattr(release, 'preflight_branches', lambda packages, rel, base, merge, release_current: [])
+    monkeypatch.setattr(release, 'preflight_release_tags', lambda packages, release_name, merge, release_current: [])
+    monkeypatch.setattr(release, 'preflight_clean_worktrees', lambda packages: [])
+    monkeypatch.setattr(release, 'check_gh_installed', lambda: True)
+    monkeypatch.setattr(release, 'validate_gh_access', lambda: True)
+    monkeypatch.setattr(release, 'get_repository', lambda p: object())
+    monkeypatch.setattr(release, 'fetch_tags', lambda repo: None)
+    monkeypatch.setattr(release, 'has_unreleased_commits', lambda repo, branch: False)
+    actions = []
+    monkeypatch.setattr(release, 'create_release', lambda *args: actions.append('release'))
+
+    failed = release.main('v2.0.0-alpha1', None, '2.x', 'cfg', False, True, False, False, False)
 
     assert failed == []
     assert actions == []
@@ -323,6 +365,48 @@ def test_release_cli_requires_release_branch(monkeypatch):
     assert 'release-branch' in captured['msg']
 
 
+def test_release_cli_rejects_release_branch_with_release_current(monkeypatch):
+    monkeypatch.setattr(release, 'check_gh_installed', lambda: True)
+    captured = {}
+
+    def fake_error(self, message):
+        captured['msg'] = message
+        raise SystemExit(2)
+
+    monkeypatch.setattr(argparse.ArgumentParser, 'error', fake_error, raising=False)
+    with pytest.raises(SystemExit):
+        release.run_cli(['--release-current', '--base-branch', '2.x', '--release-branch', 'release/1', '--config', 'cfg', 'rel'])
+    assert 'cannot be used with --release-current' in captured['msg']
+
+
+def test_release_cli_rejects_merge_with_release_current(monkeypatch):
+    monkeypatch.setattr(release, 'check_gh_installed', lambda: True)
+    captured = {}
+
+    def fake_error(self, message):
+        captured['msg'] = message
+        raise SystemExit(2)
+
+    monkeypatch.setattr(argparse.ArgumentParser, 'error', fake_error, raising=False)
+    with pytest.raises(SystemExit):
+        release.run_cli(['--release-current', '--merge', '--base-branch', '2.x', '--config', 'cfg', 'rel'])
+    assert '--merge cannot be used with --release-current' in captured['msg']
+
+
+def test_release_cli_rejects_force_release_without_release_current(monkeypatch):
+    monkeypatch.setattr(release, 'check_gh_installed', lambda: True)
+    captured = {}
+
+    def fake_error(self, message):
+        captured['msg'] = message
+        raise SystemExit(2)
+
+    monkeypatch.setattr(argparse.ArgumentParser, 'error', fake_error, raising=False)
+    with pytest.raises(SystemExit):
+        release.run_cli(['--force-release', '--base-branch', '2.x', '--release-branch', 'release/1', '--config', 'cfg', 'rel'])
+    assert '--force-release can only be used with --release-current' in captured['msg']
+
+
 def test_release_cli_exits_non_zero_on_failed_packages(monkeypatch):
     monkeypatch.setattr(release, 'main', lambda *args: ['pkg'])
     monkeypatch.setattr(release, 'os', os)
@@ -349,7 +433,7 @@ def test_preflight_branches_fails_for_missing_base_branch(monkeypatch, tmp_path)
     monkeypatch.setattr(release, 'has_remote_branch', lambda repo, branch: branch == 'release/1')
     monkeypatch.setattr(release, 'check_for_merged_prs', lambda cwd, branch: False)
 
-    failed = release.preflight_branches(paths, 'release/1', '2.x', False)
+    failed = release.preflight_branches(paths, 'release/1', '2.x', False, False)
 
     assert failed == ['pkg']
 
@@ -362,7 +446,7 @@ def test_preflight_branches_fails_for_missing_release_branch_in_prepare(monkeypa
     monkeypatch.setattr(release, 'has_remote_branch', lambda repo, branch: branch == '2.x')
     monkeypatch.setattr(release, 'check_for_merged_prs', lambda cwd, branch: False)
 
-    failed = release.preflight_branches(paths, 'release/1', '2.x', False)
+    failed = release.preflight_branches(paths, 'release/1', '2.x', False, False)
 
     assert failed == ['pkg']
 
@@ -375,7 +459,7 @@ def test_preflight_branches_allows_missing_release_branch_for_merged_pr_recovery
     monkeypatch.setattr(release, 'has_remote_branch', lambda repo, branch: branch == '2.x')
     monkeypatch.setattr(release, 'check_for_merged_prs', lambda cwd, branch: True)
 
-    failed = release.preflight_branches(paths, 'release/1', '2.x', True)
+    failed = release.preflight_branches(paths, 'release/1', '2.x', True, False)
 
     assert failed == []
 
@@ -385,11 +469,11 @@ def test_release_main_returns_preflight_failures_without_processing(monkeypatch,
     monkeypatch.setattr(release, 'read_packages', lambda f: paths)
     monkeypatch.setattr(release, 'check_gh_installed', lambda: True)
     monkeypatch.setattr(release, 'validate_gh_access', lambda: True)
-    monkeypatch.setattr(release, 'preflight_branches', lambda packages, rel, base, merge: ['pkg'])
+    monkeypatch.setattr(release, 'preflight_branches', lambda packages, rel, base, merge, release_current: ['pkg'])
     called = []
     monkeypatch.setattr(release, 'get_repository', lambda p: called.append('repo'))
 
-    failed = release.main('v1', 'release/1', '2.x', 'cfg', False, False, False)
+    failed = release.main('v1', 'release/1', '2.x', 'cfg', False, False, False, False, False)
 
     assert failed == ['pkg']
     assert called == []
@@ -402,7 +486,7 @@ def test_preflight_release_tags_fails_for_existing_tag(monkeypatch, tmp_path):
     monkeypatch.setattr(release, 'fetch_tags', lambda repo: None)
     monkeypatch.setattr(release, 'has_tag', lambda repo, tag_name: tag_name == 'v2.0.0-alpha1')
 
-    failed = release.preflight_release_tags(paths, 'v2.0.0-alpha1', True)
+    failed = release.preflight_release_tags(paths, 'v2.0.0-alpha1', True, False)
 
     assert failed == ['pkg']
 
@@ -412,7 +496,7 @@ def test_preflight_release_tags_skips_non_merge_mode(monkeypatch, tmp_path):
     called = []
     monkeypatch.setattr(release, 'get_repository', lambda p: called.append('repo'))
 
-    failed = release.preflight_release_tags(paths, 'v2.0.0-alpha1', False)
+    failed = release.preflight_release_tags(paths, 'v2.0.0-alpha1', False, False)
 
     assert failed == []
     assert called == []
@@ -423,12 +507,12 @@ def test_release_main_returns_tag_preflight_failures_without_processing(monkeypa
     monkeypatch.setattr(release, 'read_packages', lambda f: paths)
     monkeypatch.setattr(release, 'check_gh_installed', lambda: True)
     monkeypatch.setattr(release, 'validate_gh_access', lambda: True)
-    monkeypatch.setattr(release, 'preflight_branches', lambda packages, rel, base, merge: [])
-    monkeypatch.setattr(release, 'preflight_release_tags', lambda packages, release_name, merge: ['pkg'])
+    monkeypatch.setattr(release, 'preflight_branches', lambda packages, rel, base, merge, release_current: [])
+    monkeypatch.setattr(release, 'preflight_release_tags', lambda packages, release_name, merge, release_current: ['pkg'])
     called = []
     monkeypatch.setattr(release, 'get_repository', lambda p: called.append('repo'))
 
-    failed = release.main('v2.0.0-alpha1', 'release/1', '2.x', 'cfg', True, False, False)
+    failed = release.main('v2.0.0-alpha1', 'release/1', '2.x', 'cfg', True, False, False, False, False)
 
     assert failed == ['pkg']
     assert called == []
@@ -477,12 +561,12 @@ def test_release_main_returns_worktree_preflight_failures_without_processing(mon
     monkeypatch.setattr(release, 'read_packages', lambda f: paths)
     monkeypatch.setattr(release, 'check_gh_installed', lambda: True)
     monkeypatch.setattr(release, 'validate_gh_access', lambda: True)
-    monkeypatch.setattr(release, 'preflight_branches', lambda packages, rel, base, merge: [])
+    monkeypatch.setattr(release, 'preflight_branches', lambda packages, rel, base, merge, release_current: [])
     monkeypatch.setattr(release, 'preflight_clean_worktrees', lambda packages: ['pkg'])
     called = []
     monkeypatch.setattr(release, 'get_repository', lambda p: called.append('repo'))
 
-    failed = release.main('v1', 'release/1', '2.x', 'cfg', False, False, False)
+    failed = release.main('v1', 'release/1', '2.x', 'cfg', False, False, False, False, False)
 
     assert failed == ['pkg']
     assert called == []
@@ -491,8 +575,8 @@ def test_release_main_returns_worktree_preflight_failures_without_processing(mon
 def test_release_main_skips_worktree_preflight_in_merge_mode(monkeypatch, tmp_path):
     paths = {'pkg': str(tmp_path)}
     monkeypatch.setattr(release, 'read_packages', lambda f: paths)
-    monkeypatch.setattr(release, 'preflight_branches', lambda packages, rel, base, merge: [])
-    monkeypatch.setattr(release, 'preflight_release_tags', lambda packages, release_name, merge: [])
+    monkeypatch.setattr(release, 'preflight_branches', lambda packages, rel, base, merge, release_current: [])
+    monkeypatch.setattr(release, 'preflight_release_tags', lambda packages, release_name, merge, release_current: [])
     called = []
     monkeypatch.setattr(release, 'preflight_clean_worktrees', lambda packages: called.append('worktree') or ['pkg'])
     monkeypatch.setattr(release, 'check_gh_installed', lambda: True)
@@ -502,7 +586,7 @@ def test_release_main_skips_worktree_preflight_in_merge_mode(monkeypatch, tmp_pa
     monkeypatch.setattr(release, 'check_for_open_prs', lambda cwd, b: False)
     monkeypatch.setattr(release, 'check_for_merged_prs', lambda cwd, b: False)
 
-    failed = release.main('v1', 'release/1', '2.x', 'cfg', True, False, False)
+    failed = release.main('v1', 'release/1', '2.x', 'cfg', True, False, False, False, False)
 
     assert failed == []
     assert called == []
@@ -525,6 +609,8 @@ def test_plan_package_action_reports_blocked_dirty_prepare_repo(monkeypatch, tmp
         'v2.0.0-alpha1',
         'release/1',
         '2.x',
+        False,
+        False,
         False,
         False,
         False
@@ -550,6 +636,8 @@ def test_plan_package_action_reports_existing_release_tag(monkeypatch, tmp_path)
         '2.x',
         True,
         False,
+        False,
+        False,
         False
     )
 
@@ -567,7 +655,7 @@ def test_release_main_dry_run_uses_preview_without_running_preflight(monkeypatch
     monkeypatch.setattr(release, 'preflight_branches', lambda *args: called.append('branches') or [])
     monkeypatch.setattr(release, 'preflight_clean_worktrees', lambda *args: called.append('worktrees') or [])
 
-    failed = release.main('v1', 'release/1', '2.x', 'cfg', False, False, False, dry_run=True)
+    failed = release.main('v1', 'release/1', '2.x', 'cfg', False, False, False, False, False, dry_run=True)
 
     assert failed == []
     assert called == []
@@ -580,9 +668,56 @@ def test_release_main_status_returns_blocked_preview_packages(monkeypatch, tmp_p
     monkeypatch.setattr(release, 'validate_gh_access', lambda: True)
     monkeypatch.setattr(release, 'preview_actions', lambda *args: ['pkg'])
 
-    failed = release.main('v1', 'release/1', '2.x', 'cfg', False, False, False, status=True)
+    failed = release.main('v1', 'release/1', '2.x', 'cfg', False, False, False, False, False, status=True)
 
     assert failed == ['pkg']
+
+
+def test_release_main_release_current_force_release_ignores_unreleased_commit_check(monkeypatch, tmp_path):
+    paths = {'pkg': str(tmp_path)}
+    monkeypatch.setattr(release, 'read_packages', lambda f: paths)
+    monkeypatch.setattr(release, 'preflight_branches', lambda packages, rel, base, merge, release_current: [])
+    monkeypatch.setattr(release, 'preflight_release_tags', lambda packages, release_name, merge, release_current: [])
+    monkeypatch.setattr(release, 'preflight_clean_worktrees', lambda packages: [])
+    monkeypatch.setattr(release, 'check_gh_installed', lambda: True)
+    monkeypatch.setattr(release, 'validate_gh_access', lambda: True)
+    monkeypatch.setattr(release, 'get_repository', lambda p: object())
+    monkeypatch.setattr(release, 'fetch_tags', lambda repo: None)
+    monkeypatch.setattr(release, 'has_unreleased_commits', lambda repo, branch: False)
+    monkeypatch.setattr(release, 'checkout', lambda repo, package, branch: None)
+    monkeypatch.setattr(release, 'collect_release_notes', lambda r, b: 'notes')
+    actions = []
+    monkeypatch.setattr(release, 'create_release', lambda cwd, base, rel, notes: actions.append((base, rel, notes)))
+
+    failed = release.main('v2.0.0-alpha1', None, '2.x', 'cfg', False, True, True, False, False)
+
+    assert failed == []
+    assert actions == [('2.x', 'v2.0.0-alpha1', 'notes')]
+
+
+def test_plan_package_action_reports_force_release_from_current_branch(monkeypatch, tmp_path):
+    repo = SimpleNamespace(is_dirty=lambda untracked_files=True: False)
+    monkeypatch.setattr(release, 'get_repository', lambda p: repo)
+    monkeypatch.setattr(release, 'fetch_remote', lambda repo: None)
+    monkeypatch.setattr(release, 'fetch_tags', lambda repo: None)
+    monkeypatch.setattr(release, 'has_remote_branch', lambda repo, branch: True)
+    monkeypatch.setattr(release, 'has_tag', lambda repo, tag_name: False)
+
+    action, blocked = release.plan_package_action(
+        'pkg',
+        str(tmp_path),
+        'v2.0.0-alpha1',
+        None,
+        '2.x',
+        False,
+        True,
+        True,
+        False,
+        False
+    )
+
+    assert blocked is False
+    assert action == 'would force-create release `v2.0.0-alpha1` from `2.x`'
 
 
 def test_collect_release_notes_uses_commit_subjects_for_squash_flow(tmp_path):


### PR DESCRIPTION
## Summary

This MR syncs the latest release-tooling improvements from `origin-public/2.x` into `micro-php/2.x`.

The main focus is hardening the multi-repo initialization and release flow for Micro PHP packages, making the tooling safer, more
explicit, and easier to operate for first releases and ongoing package releases.

## What Changed

- improved `init` flow for package repositories
- added cleanup tooling to undo nested package git initialization
- hardened release automation with safer preflight checks
- added direct release mode for publishing from the current branch without PRs
- added forced release support for cases where a tag/release is needed even without new commits
- added dry-run and status modes for release planning
- documented the scripts workflow
- added automated Python test coverage for the scripts

## Key Improvements

### Init flow
- support `--from-branch` fallback when the target branch does not exist in package repos
- support `--push-missing-branches` as an opt-in
- avoid destructive defaults during initialization
- improve handling of freshly initialized package repos inside the monorepo

### Release flow
- require explicit branch inputs
- validate GitHub CLI auth before package processing
- preflight remote branch existence before running release actions
- preflight release tags before attempting publication
- fail early on dirty worktrees for prepare/direct-release flows
- fail the overall run when any package fails
- recover from the case where a PR is already merged but the release was not created
- generate release notes in a way that matches squash-merge flow
- support `--dry-run` and `--status`
- support `--release-current` for tag/release creation directly from the base branch
- support `--force-release` for first-line releases and other explicit no-commit release cases

### Tooling and docs
- add `scripts/clean.py`
- extend `Makefile` targets for preview and direct release flows
- add `scripts/README.md` with release instructions
- add Python test suite and workflow coverage for the scripts

## Why

The previous release flow was too easy to misuse:
- destructive branch/reset behavior during init
- incomplete preflight validation
- PR/release state mismatches
- no clean way to perform a first release for an existing branch line
- limited operator visibility before mutating repositories

This MR makes the release tooling much more predictable and operationally safe.

## Testing

- added unit/integration-style Python tests for script behavior
- verified script test suite passes locally

```bash
python -m pytest tests/python -q
```

## Notes

This branch is ahead of micro-php/2.x by 5 commits and includes the release-tooling changes needed to support the first 2.x
package releases, including 2.0.0-alpha1.